### PR TITLE
Initialize database schema with Alembic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
 # agent-backend
-this is a fast api backend to handle interaction between agent and database 
+This repository uses Alembic for database migrations. To set up the project loca
+lly:
+
+1. Create a `.env` file in the project root with the variable `DATABASE_URL` poi
+   nting to your PostgreSQL instance. Example:
+
+   ```ini
+   DATABASE_URL=postgresql+psycopg2://user:password@localhost:5432/agent_db
+   ```
+
+2. Install dependencies (Alembic and Psycopg):
+
+   ```bash
+   pip install alembic psycopg2-binary
+   ```
+
+3. Run the migrations:
+
+   ```bash
+   alembic upgrade head
+   ```
+
+This will create the initial schema for clients, client users, conversations, m
+essages and leads using auto-incrementing integer primary keys.
+

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,149 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts.
+# this is typically a path given in POSIX (e.g. forward slashes)
+# format, relative to the token %(here)s which refers to the location of this
+# ini file
+script_location = %(here)s/alembic
+
+# template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
+# Uncomment the line below if you want the files to be prepended with date and time
+# see https://alembic.sqlalchemy.org/en/latest/tutorial.html#editing-the-ini-file
+# for all available tokens
+# file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
+
+# sys.path path, will be prepended to sys.path if present.
+# defaults to the current working directory.  for multiple paths, the path separator
+# is defined by "path_separator" below.
+prepend_sys_path = .
+
+
+# timezone to use when rendering the date within the migration file
+# as well as the filename.
+# If specified, requires the python>=3.9 or backports.zoneinfo library and tzdata library.
+# Any required deps can installed by adding `alembic[tz]` to the pip requirements
+# string value is passed to ZoneInfo()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; This defaults
+# to <script_location>/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path.
+# The path separator used here should be the separator specified by "path_separator"
+# below.
+# version_locations = %(here)s/bar:%(here)s/bat:%(here)s/alembic/versions
+
+# path_separator; This indicates what character is used to split lists of file
+# paths, including version_locations and prepend_sys_path within configparser
+# files such as alembic.ini.
+# The default rendered in new alembic.ini files is "os", which uses os.pathsep
+# to provide os-dependent path splitting.
+#
+# Note that in order to support legacy alembic.ini files, this default does NOT
+# take place if path_separator is not present in alembic.ini.  If this
+# option is omitted entirely, fallback logic is as follows:
+#
+# 1. Parsing of the version_locations option falls back to using the legacy
+#    "version_path_separator" key, which if absent then falls back to the legacy
+#    behavior of splitting on spaces and/or commas.
+# 2. Parsing of the prepend_sys_path option falls back to the legacy
+#    behavior of splitting on spaces, commas, or colons.
+#
+# Valid values for path_separator are:
+#
+# path_separator = :
+# path_separator = ;
+# path_separator = space
+# path_separator = newline
+#
+# Use os.pathsep. Default configuration used for new projects.
+path_separator = os
+
+# set to 'true' to search source files recursively
+# in each "version_locations" directory
+# new in Alembic version 1.10
+# recursive_version_locations = false
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+# database URL.  This is consumed by the user-maintained env.py script only.
+# other means of configuring database URLs may be customized within the env.py
+# file.
+# Database URL; Alembic will read from the DATABASE_URL environment variable
+# if set. Example: postgresql+psycopg2://user:password@localhost/dbname
+sqlalchemy.url =
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks = black
+# black.type = console_scripts
+# black.entrypoint = black
+# black.options = -l 79 REVISION_SCRIPT_FILENAME
+
+# lint with attempts to fix using "ruff" - use the module runner, against the "ruff" module
+# hooks = ruff
+# ruff.type = module
+# ruff.module = ruff
+# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# Alternatively, use the exec runner to execute a binary found on your PATH
+# hooks = ruff
+# ruff.type = exec
+# ruff.executable = ruff
+# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# Logging configuration.  This is also consumed by the user-maintained
+# env.py script only.
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/alembic/README
+++ b/alembic/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,83 @@
+from logging.config import fileConfig
+
+import os
+from sqlalchemy import engine_from_config
+from sqlalchemy import pool
+
+from alembic import context
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+target_metadata = None
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = os.getenv("DATABASE_URL", config.get_main_option("sqlalchemy.url"))
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    configuration = config.get_section(config.config_ini_section, {})
+    configuration["sqlalchemy.url"] = os.getenv(
+        "DATABASE_URL", configuration.get("sqlalchemy.url")
+    )
+    connectable = engine_from_config(
+        configuration,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection, target_metadata=target_metadata
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,28 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, Sequence[str], None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    ${downgrades if downgrades else "pass"}

--- a/alembic/versions/0001_initial_schema.py
+++ b/alembic/versions/0001_initial_schema.py
@@ -1,0 +1,145 @@
+"""initial schema
+
+Revision ID: 0001
+Revises: 
+Create Date: 2025-07-11 18:18:59.324328
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = '0001'
+down_revision: Union[str, Sequence[str], None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    conversation_status = sa.Enum(
+        "open",
+        "pending",
+        "closed",
+        name="conversation_status",
+    )
+    lead_status = sa.Enum(
+        "new",
+        "interested",
+        "negotiating",
+        "closed_won",
+        "closed_lost",
+        name="lead_status",
+    )
+
+
+    op.create_table(
+        "clients",
+        sa.Column(
+            "id",
+            sa.Integer,
+            sa.Identity(always=True),
+            primary_key=True,
+            nullable=False,
+        ),
+        sa.Column("name", sa.Text, nullable=False),
+        sa.Column("industry", sa.Text, nullable=True),
+        sa.Column("phone", sa.Text, nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+    )
+
+    op.create_table(
+        "client_users",
+        sa.Column("id", sa.Integer, sa.Identity(always=True), primary_key=True),
+        sa.Column("client_id", sa.Integer, sa.ForeignKey("clients.id"), nullable=False),
+        sa.Column("name", sa.Text, nullable=False),
+        sa.Column("phone", sa.Text, nullable=False),
+        sa.Column("email", sa.Text, nullable=False),
+        sa.Column("direction", sa.Text, nullable=False),
+        sa.Column("metadata", postgresql.JSONB, nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+    )
+
+    op.create_table(
+        "conversations",
+        sa.Column("id", sa.Integer, sa.Identity(always=True), primary_key=True),
+        sa.Column("client_id", sa.Integer, sa.ForeignKey("clients.id"), nullable=False),
+        sa.Column(
+            "user_id", sa.Integer, sa.ForeignKey("client_users.id"), nullable=False
+        ),
+        sa.Column(
+            "started_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("status", conversation_status, nullable=False),
+        sa.Column("metadata", postgresql.JSONB, nullable=True),
+    )
+
+    op.create_table(
+        "messages",
+        sa.Column("id", sa.Integer, sa.Identity(always=True), primary_key=True),
+        sa.Column(
+            "conversation_id", sa.Integer, sa.ForeignKey("conversations.id"), nullable=False
+        ),
+        sa.Column("client_id", sa.Integer, sa.ForeignKey("clients.id"), nullable=False),
+        sa.Column("content", sa.Text, nullable=True),
+        sa.Column("content_type", sa.Text, nullable=True),
+        sa.Column("wa_msg_id", sa.Text, nullable=True),
+        sa.Column("wa_status", sa.Text, nullable=True),
+        sa.Column(
+            "timestamp",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column("metadata", postgresql.JSONB, nullable=True),
+    )
+
+    op.create_table(
+        "leads",
+        sa.Column("id", sa.Integer, sa.Identity(always=True), primary_key=True),
+        sa.Column("client_id", sa.Integer, sa.ForeignKey("clients.id"), nullable=False),
+        sa.Column(
+            "user_id", sa.Integer, sa.ForeignKey("client_users.id"), nullable=False
+        ),
+        sa.Column(
+            "conversation_id",
+            sa.Integer,
+            sa.ForeignKey("conversations.id"),
+            nullable=True,
+        ),
+        sa.Column("status", lead_status, nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table("leads")
+    op.drop_table("messages")
+    op.drop_table("conversations")
+    op.drop_table("client_users")
+    op.drop_table("clients")
+    op.execute(sa.text("DROP TYPE IF EXISTS lead_status"))
+    op.execute(sa.text("DROP TYPE IF EXISTS conversation_status"))


### PR DESCRIPTION
## Summary
- setup Alembic and configuration for DATABASE_URL env var
- add initial migration creating clients, client_users, conversations, messages and leads tables
- document how to run migrations

## Testing
- `alembic upgrade head`
- `alembic downgrade base`


------
https://chatgpt.com/codex/tasks/task_e_6871554fc5f88332920653780b97f299