### PR TITLE
Support local DB credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,26 +19,54 @@ Run tests:
 pytest -q
 ```
 
-Database credentials are always fetched from **Azure Key Vault**. Set the
-`KEY_VAULT_URL` environment variable to your vault URL, e.g.
-`https://kv-r8fm.vault.azure.net/`. The vault must
-contain the following secrets:
+Database credentials can be loaded from **Azure Key Vault** or directly from
+environment variables. If the `KEY_VAULT_URL` variable is set, the application
+will read secrets from your vault (e.g. `https://kv-r8fm.vault.azure.net/`). The
+vault must contain the following secrets:
 
 - `DBUSERNAME`
 - `psqladmin-password`
 - `DBHOST`
 - `DBNAME`
 
-The `.env` file in `sales_agent_api/` shows how to provide the vault URL during
-development. It contains a single line specifying your Key Vault. Replace the
-value if your vault URL differs:
+If `KEY_VAULT_URL` is **not** provided, credentials must instead come from the
+following environment variables (their Key Vault equivalents like `DBUSERNAME`
+are also accepted):
+
+- `DB_USERNAME`
+- `DB_PASSWORD`
+- `DB_HOST`
+- `DB_NAME`
+
+The `.env` file in `sales_agent_api/` is loaded automatically when the app
+starts, so you can place your local credentials there. Replace the values as
+needed:
 
 ```dotenv
-KEY_VAULT_URL=https://<your-keyvault-name>.vault.azure.net/
+# KEY_VAULT_URL=https://<your-keyvault-name>.vault.azure.net/
+DB_USERNAME=your-user
+DB_PASSWORD=your-pass
+DB_HOST=localhost
+DB_NAME=testdb
 ```
 
 ## API Endpoints
 
 - `GET /` – Welcome message.
 - `GET /health` – Returns a simple payload confirming the backend is reachable.
+
+## Docker
+
+The repository's Dockerfile lives in the `sales_agent_api/` directory. Build
+the image using that directory as the build context:
+
+```bash
+docker build -t sales-agent-api -f sales_agent_api/Dockerfile sales_agent_api
+```
+
+Running the container exposes the API on port 8000:
+
+```bash
+docker run -p 8000:8000 sales-agent-api
+```
 

--- a/sales_agent_api/.env
+++ b/sales_agent_api/.env
@@ -1,2 +1,8 @@
-# URL of your Azure Key Vault
-KEY_VAULT_URL=https://kv-r8fm.vault.azure.net/
+# URL of your Azure Key Vault (optional)
+# KEY_VAULT_URL=https://<your-keyvault-name>.vault.azure.net/
+
+# Local credentials
+DB_USERNAME=your-user
+DB_PASSWORD=your-pass
+DB_HOST=localhost
+DB_NAME=testdb

--- a/sales_agent_api/Dockerfile
+++ b/sales_agent_api/Dockerfile
@@ -7,4 +7,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
-CMD ["uvicorn", "sales_agent_api.app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# When building the image the context is the `sales_agent_api` directory, so the
+# package itself is located at `/app`. Run uvicorn using the local package name
+# rather than `sales_agent_api`.
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/sales_agent_api/app/db.py
+++ b/sales_agent_api/app/db.py
@@ -4,26 +4,41 @@ from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 from sqlalchemy.orm import sessionmaker
 import os
 from dotenv import load_dotenv
+from pathlib import Path
 from azure.identity import DefaultAzureCredential
 from azure.keyvault.secrets import SecretClient
 
-load_dotenv()
+load_dotenv(Path(__file__).resolve().parents[1] / ".env")
 
 
 def _load_db_settings():
-    """Load database credentials from Azure Key Vault."""
+    """Load database credentials from Azure Key Vault or environment vars."""
 
     vault_url = os.getenv("KEY_VAULT_URL")
-    if not vault_url:
-        raise RuntimeError("KEY_VAULT_URL environment variable must be set")
+    if vault_url:
+        credential = DefaultAzureCredential()
+        client = SecretClient(vault_url=vault_url, credential=credential)
 
-    credential = DefaultAzureCredential()
-    client = SecretClient(vault_url=vault_url, credential=credential)
-
-    username = client.get_secret("DBUSERNAME").value
-    password = client.get_secret("psqladmin-password").value
-    host = client.get_secret("DBHOST").value
-    name = client.get_secret("DBNAME").value
+        username = client.get_secret("DBUSERNAME").value
+        password = client.get_secret("psqladmin-password").value
+        host = client.get_secret("DBHOST").value
+        name = client.get_secret("DBNAME").value
+    else:
+        username = os.getenv("DB_USERNAME") or os.getenv("DBUSERNAME")
+        password = (
+            os.getenv("DB_PASSWORD")
+            or os.getenv("DBPASSWORD")
+            or os.getenv("PSQLADMIN_PASSWORD")
+            or os.getenv("psqladmin-password")
+        )
+        host = os.getenv("DB_HOST") or os.getenv("DBHOST")
+        name = os.getenv("DB_NAME") or os.getenv("DBNAME")
+        if not all([username, password, host, name]):
+            raise RuntimeError(
+                "Database credentials not found. Provide KEY_VAULT_URL or set "
+                "DB_USERNAME (or DBUSERNAME), DB_PASSWORD (or DBPASSWORD), "
+                "DB_HOST (or DBHOST), and DB_NAME (or DBNAME)."
+            )
 
     return username, password, host, name
 

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -45,3 +45,51 @@ def test_health_endpoint(monkeypatch):
         }
 
 
+def test_health_endpoint_local_env(monkeypatch):
+    """Verify the health endpoint using local environment variables."""
+
+    monkeypatch.delenv("KEY_VAULT_URL", raising=False)
+    monkeypatch.setenv("DB_USERNAME", "user")
+    monkeypatch.setenv("DB_PASSWORD", "pass")
+    monkeypatch.setenv("DB_HOST", "localhost")
+    monkeypatch.setenv("DB_NAME", "testdb")
+
+    import sales_agent_api.app.db as db
+    import importlib
+    importlib.reload(db)
+
+    from sales_agent_api.app.main import app
+
+    client = TestClient(app)
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "ok",
+        "message": "Backend reachable by LLM",
+    }
+
+
+def test_health_endpoint_dotenv(monkeypatch):
+    """Verify credentials are loaded from the packaged .env file."""
+
+    monkeypatch.delenv("KEY_VAULT_URL", raising=False)
+    monkeypatch.delenv("DB_USERNAME", raising=False)
+    monkeypatch.delenv("DB_PASSWORD", raising=False)
+    monkeypatch.delenv("DB_HOST", raising=False)
+    monkeypatch.delenv("DB_NAME", raising=False)
+
+    import sales_agent_api.app.db as db
+    import importlib
+    importlib.reload(db)
+
+    from sales_agent_api.app.main import app
+
+    client = TestClient(app)
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "ok",
+        "message": "Backend reachable by LLM",
+    }
+
+


### PR DESCRIPTION
## Summary
- allow loading DB credentials from env vars or `.env`
- read `.env` relative to the package path
- accept legacy env names like DBUSERNAME
- document local credential loading
- test `.env` loading
- fix Docker CMD to use the local package path
- document how to build/run the Docker image

## Testing
- `pip install -r sales_agent_api/requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883a40b36f883329f51f496be673cd5