### PR TITLE
Add user lookup endpoint

### DIFF
--- a/sales_agent_api/app/main.py
+++ b/sales_agent_api/app/main.py
@@ -1,7 +1,10 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Depends
 from contextlib import asynccontextmanager
+from sqlmodel.ext.asyncio.session import AsyncSession
+from sqlmodel import select
 
-from .db import init_db
+from .db import init_db, get_session
+from .models import ClientUser, Client
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -19,4 +22,33 @@ async def root():
 async def health_check():
     """Endpoint used by the LLM to verify connectivity with the backend."""
     return {"status": "ok", "message": "Backend reachable by LLM"}
+
+
+@app.get("/users/by-phone/{phone_number}")
+async def user_by_phone(
+    phone_number: str, session: AsyncSession = Depends(get_session)
+):
+    """Lookup a client user by their WhatsApp phone number."""
+
+    statement = (
+        select(ClientUser)
+        .join(Client)
+        .where(Client.name == "cafe arenillo")
+        .where(ClientUser.phone_number == phone_number)
+    )
+    result = await session.exec(statement)
+    user = result.first()
+
+    if user:
+        return {
+            "exists": True,
+            "name": user.name,
+            "user_id": user.id,
+            "client_id": user.client_id,
+        }
+
+    return {
+        "exists": False,
+        "message": "Please ask the user for their name to continue.",
+    }
 

--- a/sales_agent_api/app/models.py
+++ b/sales_agent_api/app/models.py
@@ -1,0 +1,18 @@
+from typing import Optional, List
+from sqlmodel import SQLModel, Field, Relationship
+
+
+class Client(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+
+    users: List["ClientUser"] | None = Relationship(back_populates="client")
+
+
+class ClientUser(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    client_id: int = Field(foreign_key="client.id")
+    name: str
+    phone_number: str
+
+    client: Optional[Client] = Relationship(back_populates="users")

--- a/sales_agent_api/requirements.txt
+++ b/sales_agent_api/requirements.txt
@@ -2,6 +2,7 @@ fastapi
 uvicorn
 sqlmodel
 asyncpg
+aiosqlite
 python-dotenv
 httpx>=0.23,<0.25
 azure-identity

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -34,6 +34,11 @@ def test_health_endpoint(monkeypatch):
         import sales_agent_api.app.db as db
         importlib.reload(db)
 
+        async def dummy_init_db():
+            pass
+
+        db.init_db = dummy_init_db
+
         from sales_agent_api.app.main import app
 
         client = TestClient(app)
@@ -58,6 +63,11 @@ def test_health_endpoint_local_env(monkeypatch):
     import importlib
     importlib.reload(db)
 
+    async def dummy_init_db():
+        pass
+
+    db.init_db = dummy_init_db
+
     from sales_agent_api.app.main import app
 
     client = TestClient(app)
@@ -81,6 +91,11 @@ def test_health_endpoint_dotenv(monkeypatch):
     import sales_agent_api.app.db as db
     import importlib
     importlib.reload(db)
+
+    async def dummy_init_db():
+        pass
+
+    db.init_db = dummy_init_db
 
     from sales_agent_api.app.main import app
 

--- a/tests/test_user_lookup.py
+++ b/tests/test_user_lookup.py
@@ -1,0 +1,104 @@
+from fastapi.testclient import TestClient
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.orm import sessionmaker
+import sys
+from pathlib import Path
+import importlib
+import asyncio
+
+# Ensure the sales_agent_api package is on the path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sales_agent_api.app.models import Client, ClientUser
+
+
+def setup_test_db(monkeypatch):
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def get_session_override():
+        async with async_session() as session:
+            yield session
+
+    async def init_db_override():
+        async with engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+
+    import sales_agent_api.app.db as db
+    monkeypatch.setattr(db, "get_session", get_session_override)
+    monkeypatch.setattr(db, "init_db", init_db_override)
+
+    return engine, async_session
+
+
+def create_app(monkeypatch):
+    monkeypatch.delenv("KEY_VAULT_URL", raising=False)
+    monkeypatch.setenv("DBUSERNAME", "user")
+    monkeypatch.setenv("DBPASSWORD", "pass")
+    monkeypatch.setenv("DBHOST", "localhost")
+    monkeypatch.setenv("DBNAME", "testdb")
+
+    import sales_agent_api.app.db as db
+    importlib.reload(db)
+
+    engine, async_session = setup_test_db(monkeypatch)
+
+    async def init_tables():
+        async with engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+
+    asyncio.run(init_tables())
+
+    import sales_agent_api.app.main as main
+    importlib.reload(main)
+
+    return main.app, engine, async_session
+
+
+def test_user_found(monkeypatch):
+    app, engine, async_session = create_app(monkeypatch)
+
+    async def populate():
+        async with async_session() as session:
+            client = Client(id=1, name="cafe arenillo")
+            session.add(client)
+            await session.commit()
+            user = ClientUser(name="Alice", phone_number="123", client_id=1)
+            session.add(user)
+            await session.commit()
+            await session.refresh(user)
+            return user.id
+
+    user_id = asyncio.run(populate())
+
+    client = TestClient(app)
+    response = client.get("/users/by-phone/123")
+    assert response.status_code == 200
+    assert response.json() == {
+        "exists": True,
+        "name": "Alice",
+        "user_id": user_id,
+        "client_id": 1,
+    }
+
+
+def test_user_not_found(monkeypatch):
+    app, engine, async_session = create_app(monkeypatch)
+
+    async def populate():
+        async with async_session() as session:
+            client = Client(id=1, name="cafe arenillo")
+            session.add(client)
+            await session.commit()
+
+    asyncio.run(populate())
+
+    client = TestClient(app)
+    response = client.get("/users/by-phone/999")
+    assert response.status_code == 200
+    assert response.json() == {
+        "exists": False,
+        "message": "Please ask the user for their name to continue.",
+    }


### PR DESCRIPTION
## Summary
- add data models for Client and ClientUser
- implement `/users/by-phone/{phone_number}` endpoint
- require `aiosqlite` for sqlite in tests
- patch DB setup in health tests
- add tests for the user lookup endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887dfdad49c8332bf5558655d8bd400