### PR TITLE
Fix test structure and align models and phone field

### DIFF
--- a/tests/test_user_lookup.py
+++ b/tests/test_user_lookup.py
@@ -62,14 +62,14 @@ def test_user_found(monkeypatch):
 
     async def populate():
         async with async_session() as session:
-            client = Client(id=1, name="cafe arenillo")
+            client = Client(client_id=1, name="cafe arenillo")
             session.add(client)
             await session.commit()
-            user = ClientUser(name="Alice", phone_number="123", client_id=1)
+            user = ClientUser(name="Alice", phone="123", client_id=1)
             session.add(user)
             await session.commit()
             await session.refresh(user)
-            return user.id
+            return user.user_id
 
     user_id = asyncio.run(populate())
 
@@ -89,7 +89,7 @@ def test_user_not_found(monkeypatch):
 
     async def populate():
         async with async_session() as session:
-            client = Client(id=1, name="cafe arenillo")
+            client = Client(client_id=1, name="cafe arenillo")
             session.add(client)
             await session.commit()
 

--- a/tests/test_user_register.py
+++ b/tests/test_user_register.py
@@ -61,7 +61,7 @@ def test_register_user(monkeypatch):
 
     async def populate():
         async with async_session() as session:
-            client = Client(id=1, name="cafe arenillo")
+            client = Client(client_id=1, name="cafe arenillo")
             session.add(client)
             await session.commit()
 
@@ -71,11 +71,13 @@ def test_register_user(monkeypatch):
     payload = {"name": "Bob", "phone": "987"}
     response = client.post("/users/register", json=payload)
     assert response.status_code == 201
-    assert response.json() == {"message": "User registered successfully"}
+    data = response.json()
+    assert data["message"] == "User registered successfully"
+    assert isinstance(data["user_id"], int)
 
     async def fetch_user():
         async with async_session() as session:
-            result = await session.exec(select(ClientUser).where(ClientUser.phone_number == "987"))
+            result = await session.exec(select(ClientUser).where(ClientUser.phone == "987"))
             return result.first()
 
     user = asyncio.run(fetch_user())


### PR DESCRIPTION
## Summary
- Align SQLModel tables with provided schema, using explicit *_id keys and JSON metadata columns
- Hash client passwords and expose helper for setting them
- Update API and tests to use new field names and verify user registration/lookup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689244ef78848332a1bb9b06bb1dba33