### PR TITLE
Fix unresolved merge conflict in database URL builder

### DIFF
--- a/sales_agent_api/app/db.py
+++ b/sales_agent_api/app/db.py
@@ -27,7 +27,6 @@ def _build_database_url() -> str:
         try:
             credential = DefaultAzureCredential()
             client = SecretClient(vault_url=vault_url, credential=credential)
-<<<<<<< HEAD
             username = client.get_secret("DBUSERNAME").value
             password = client.get_secret("DBPASSWORD").value
             host = client.get_secret("DBHOST").value
@@ -48,31 +47,6 @@ def _build_database_url() -> str:
     # external configuration.  The file is created in the current working
     # directory if it does not exist.
     return "sqlite+aiosqlite:///./sales_agent.db"
-=======
-
-            username = client.get_secret("DBUSERNAME").value
-            password = client.get_secret("DBPASSWORD").value
-            host = client.get_secret("DBHOST").value
-            name = client.get_secret("DBNAME").value
-        except Exception:
-            username = password = host = name = None
-    else:
-        username = password = host = name = None
-
-    if not all([username, password, host, name]):
-        username = username or os.getenv("DBUSERNAME")
-        password = password or os.getenv("DBPASSWORD")
-        host = host or os.getenv("DBHOST")
-        name = name or os.getenv("DBNAME")
-
-    if not all([username, password, host, name]):
-        raise RuntimeError(
-            "Database credentials not found. Provide KEY_VAULT_URL or set "
-            "DBUSERNAME, DBPASSWORD, DBHOST, and DBNAME as environment variables."
-        )
-
-    return username, password, host, name
->>>>>>> origin/main
 
 
 DATABASE_URL = _build_database_url()


### PR DESCRIPTION
## Summary
- clean up unresolved merge conflict in `db.py`
- ensure `_build_database_url` gracefully falls back to environment variables or SQLite when Key Vault secrets are unavailable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab626b4adc83329300bf27e32d3b35