### PR TITLE
feat: shipping zones, product images, human handoff, debounce & session fixes

### DIFF
--- a/sales_agent_api/app/services/agent_action.py
+++ b/sales_agent_api/app/services/agent_action.py
@@ -165,6 +165,16 @@ async def process_agent_action(
             k: v for k, v in extracted_data.items()
             if k in STRATEGY_FIELDS and v
         }
+        # Enforce DAG order: don't accept confirmation fields without shipping address
+        if strategy_updates:
+            current_context = conversation.extracted_context or {}
+            merged = {**current_context, **strategy_updates}
+            if "user_confirmation" in strategy_updates and not merged.get("shipping_address"):
+                del strategy_updates["user_confirmation"]
+                logger.warning("Rejected user_confirmation: shipping_address missing")
+            if "payment_confirmation" in strategy_updates and not merged.get("user_confirmation"):
+                del strategy_updates["payment_confirmation"]
+                logger.warning("Rejected payment_confirmation: user_confirmation missing")
         if strategy_updates:
             new_context = {**(conversation.extracted_context or {}), **strategy_updates}
             await session.execute(

--- a/sales_agent_api/app/services/goal_strategy.py
+++ b/sales_agent_api/app/services/goal_strategy.py
@@ -68,12 +68,13 @@ class StrategyDirective:
         else:
             lines.append(f"NEXT INFO NEEDED: {', '.join(self.missing_fields)}")
             lines.append(
-                f"HINT: If the moment feels natural, {self.next_action.lower()}",
+                f"HINT (low priority, only when the conversation flows there naturally): {self.next_action.lower()}",
             )
 
         lines += [
-            "But ALWAYS answer the customer's current question first.",
-            "Never interrupt a customer question to collect data.",
+            "IMPORTANT: Your priority is to have a warm, natural conversation. Answer what the customer asks.",
+            "Do NOT mention or push toward the next step unless the customer brings it up.",
+            "Never end a message with 'puedo ayudarte con el pedido' or similar sales push.",
         ]
 
         return "\n".join(lines)

--- a/sales_agent_api/app/services/ingest.py
+++ b/sales_agent_api/app/services/ingest.py
@@ -148,6 +148,22 @@ async def ingest_message(
         )
         session.add(conversation)
         await session.flush()  # get the generated id
+    else:
+        # Reset extracted_context if conversation has been idle for 30+ minutes
+        # to prevent stale data from a previous interaction polluting the new one
+        idle_minutes = (now - (conversation.last_message_at or conversation.created_at)).total_seconds() / 60
+        if idle_minutes >= 30 and conversation.extracted_context:
+            logger.info(
+                "Resetting extracted_context for conversation %s (idle %.0f min)",
+                conversation.id, idle_minutes,
+            )
+            await session.execute(
+                update(Conversation)
+                .where(Conversation.id == conversation.id)
+                .values(extracted_context={}, state="active")
+            )
+            conversation.extracted_context = {}
+            conversation.state = "active"
 
     # --- 6. Advisory lock on conversation ------------------------------------
     lock_key = int(hashlib.sha1(str(conversation.id).encode()).hexdigest(), 16) % (2**63)

--- a/sales_agent_api/app/services/prompt_context.py
+++ b/sales_agent_api/app/services/prompt_context.py
@@ -32,10 +32,12 @@ def format_business_context(
             lines.append(f"- {p['name']} ({p.get('sku', 'N/A')}): {price}")
             if desc:
                 lines.append(f"  {desc}")
+            if p.get("image_url"):
+                lines.append(f"  image_url: {p['image_url']}")
         lines.append("Only mention the price if the customer asks or shows real interest.")
         lines.append("You can ONLY sell products listed above. NEVER invent or mention products not in this catalog.")
         if any(p.get("image_url") for p in product_catalog):
-            lines.append("If the customer asks for a photo/image, include the product image_url in extracted_data as 'send_image_url'.")
+            lines.append("IMAGES: If the customer asks for a photo/image of a product, you MUST set extracted_data.send_image_url to the product's image_url shown above. The system will send the image automatically.")
         sections.append("\n".join(lines))
 
     # --- Shipping rules ---

--- a/tests/services/test_goal_strategy.py
+++ b/tests/services/test_goal_strategy.py
@@ -250,5 +250,5 @@ def test_17_prompt_lists_missing_fields():
 def test_18_prompt_answers_customer_first():
     d = engine.compute("close_sale", {"intent": "comprar"})
     prompt = d.to_prompt()
-    assert "ALWAYS answer the customer" in prompt
-    assert "Never interrupt" in prompt
+    assert "warm, natural conversation" in prompt
+    assert "Do NOT mention or push toward the next step" in prompt


### PR DESCRIPTION
## Summary

- **Shipping zones**: Expanded `shipping_rules` with zone-based approximate pricing for all of Colombia (Eje Cafetero, Antioquia, Bogotá, Valle del Cauca, Costa Caribe, resto del país)
- **Product images via WhatsApp**: Added `image_url` to products table and catalog prompt. n8n sends WhatsApp image messages when LLM sets `send_image_url` in extracted_data. Fixed node references to read from `Process Backend Response` instead of Chakra output.
- **Human handoff**: Auto-escalate to `human_handoff` when all purchase checkpoints complete. n8n sends WhatsApp notification to owner.
- **Rapid-fire debounce**: Backend waits 3s after persisting a message, then checks if a newer inbound arrived. If so, returns `should_respond: false` — the latest message responds with full context, avoiding duplicate replies.
- **Session context reset**: Reset `extracted_context` when conversation idle 30+ min, preventing stale data from prior interactions.
- **DAG order enforcement**: Backend rejects `user_confirmation` without `shipping_address`, `payment_confirmation` without `user_confirmation`.
- **Softer strategy directive**: Low-priority hints, explicit rule against sales push at end of messages.

## Test plan

- [x] 37 existing tests pass
- [x] Migration 005 applied to database
- [x] n8n workflow updated and active (17 nodes)
- [ ] Test shipping: ask "envían a Cali?" → approximate zone-based answer
- [ ] Test image: ask "foto del café" → WhatsApp image message received
- [ ] Test debounce: send 2 rapid messages → single unified response
- [ ] Test handoff: complete full purchase flow → owner gets notification
- [ ] Test session reset: wait 30+ min, send new message → clean context

🤖 Generated with [Claude Code](https://claude.com/claude-code)