### PR TITLE
Fase 2+3: arreglar bugs de flujo y simplificar backend (-40% LOC)

### DIFF
--- a/sales_agent_api/app/api/v1/ingest.py
+++ b/sales_agent_api/app/api/v1/ingest.py
@@ -40,7 +40,6 @@ class IngestMessageResponse(BaseModel):
     strategy_directive: str
     strategy_meta: dict
     strategy_version: int
-    available_actions: list[str]
     client_config: dict
     user_context: dict
     product_catalog: list[dict] = []
@@ -91,7 +90,6 @@ async def ingest_message_endpoint(
             strategy_directive="",
             strategy_meta={},
             strategy_version=0,
-            available_actions=[],
             client_config={},
             user_context={},
             recent_messages=[],

--- a/sales_agent_api/app/models/core.py
+++ b/sales_agent_api/app/models/core.py
@@ -107,8 +107,6 @@ class ClientUser(Base):
 
     client: Mapped["Client"] = relationship(back_populates="client_users")
     conversations: Mapped[list["Conversation"]] = relationship(back_populates="client_user")
-    leads: Mapped[list["Lead"]] = relationship(back_populates="client_user")
-    orders: Mapped[list["Order"]] = relationship(back_populates="client_user")
 
 
 # ---------------------------------------------------------------------------
@@ -143,7 +141,6 @@ class Product(Base):
     )
 
     client: Mapped["Client"] = relationship("Client", back_populates="products", foreign_keys=[client_id])
-    order_line_items: Mapped[list["OrderLineItem"]] = relationship("OrderLineItem", back_populates="product")
 
 
 # ---------------------------------------------------------------------------
@@ -168,12 +165,6 @@ class Conversation(Base):
     extracted_context: Mapped[dict] = mapped_column(
         JSONB, nullable=False, server_default=text("'{}'::jsonb")
     )
-    lead_id: Mapped[Optional[uuid.UUID]] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("leads.id")
-    )
-    order_id: Mapped[Optional[uuid.UUID]] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("orders.id")
-    )
     assigned_operator_id: Mapped[Optional[str]] = mapped_column(String(100))
     escalation_reason: Mapped[Optional[str]] = mapped_column(Text)
     started_at: Mapped[datetime] = mapped_column(
@@ -184,9 +175,6 @@ class Conversation(Base):
     )
     closed_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
     message_count: Mapped[int] = mapped_column(
-        Integer, nullable=False, server_default=text("0")
-    )
-    agent_turn_count: Mapped[int] = mapped_column(
         Integer, nullable=False, server_default=text("0")
     )
     created_at: Mapped[datetime] = mapped_column(
@@ -208,58 +196,6 @@ class Conversation(Base):
     client: Mapped["Client"] = relationship("Client", back_populates="conversations", foreign_keys=[client_id])
     client_user: Mapped["ClientUser"] = relationship("ClientUser", back_populates="conversations", foreign_keys=[client_user_id])
     messages: Mapped[list["Message"]] = relationship("Message", back_populates="conversation", foreign_keys="[Message.conversation_id]")
-    # One-way relationships to avoid circular back_populates issues
-    lead: Mapped[Optional["Lead"]] = relationship(
-        "Lead", foreign_keys=[lead_id], viewonly=True
-    )
-    order: Mapped[Optional["Order"]] = relationship(
-        "Order", foreign_keys=[order_id], viewonly=True
-    )
-
-
-# ---------------------------------------------------------------------------
-# leads
-# ---------------------------------------------------------------------------
-class Lead(Base):
-    __tablename__ = "leads"
-
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, server_default=text("uuid_generate_v4()")
-    )
-    client_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("clients.id"), nullable=False
-    )
-    client_user_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("client_users.id"), nullable=False
-    )
-    status: Mapped[str] = mapped_column(
-        String(20), nullable=False, server_default=text("'new'")
-    )
-    intent: Mapped[Optional[str]] = mapped_column(String(255))
-    score: Mapped[Optional[int]] = mapped_column(Integer)
-    qualification_data: Mapped[dict] = mapped_column(
-        JSONB, nullable=False, server_default=text("'{}'::jsonb")
-    )
-    source_conversation_id: Mapped[Optional[uuid.UUID]] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("conversations.id")
-    )
-    assigned_to: Mapped[Optional[str]] = mapped_column(String(100))
-    qualified_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
-    won_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
-    lost_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
-    lost_reason: Mapped[Optional[str]] = mapped_column(Text)
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=text("now()")
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=text("now()")
-    )
-
-    client_user: Mapped["ClientUser"] = relationship("ClientUser", back_populates="leads", foreign_keys=[client_user_id])
-    source_conversation: Mapped[Optional["Conversation"]] = relationship(
-        "Conversation", foreign_keys=[source_conversation_id], viewonly=True
-    )
-    orders: Mapped[list["Order"]] = relationship("Order", back_populates="lead", foreign_keys="[Order.lead_id]")
 
 
 # ---------------------------------------------------------------------------
@@ -306,93 +242,6 @@ class Message(Base):
     backend_decision_reason: Mapped[Optional[str]] = mapped_column(Text)
 
     conversation: Mapped["Conversation"] = relationship("Conversation", back_populates="messages", foreign_keys=[conversation_id])
-
-
-# ---------------------------------------------------------------------------
-# orders
-# ---------------------------------------------------------------------------
-class Order(Base):
-    __tablename__ = "orders"
-
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, server_default=text("uuid_generate_v4()")
-    )
-    client_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("clients.id"), nullable=False
-    )
-    client_user_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("client_users.id"), nullable=False
-    )
-    lead_id: Mapped[Optional[uuid.UUID]] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("leads.id")
-    )
-    status: Mapped[str] = mapped_column(
-        String(20), nullable=False, server_default=text("'draft'")
-    )
-    shipping_name: Mapped[Optional[str]] = mapped_column(String(255))
-    shipping_address: Mapped[Optional[str]] = mapped_column(Text)
-    shipping_city: Mapped[Optional[str]] = mapped_column(String(100))
-    shipping_phone: Mapped[Optional[str]] = mapped_column(String(20))
-    subtotal: Mapped[Decimal] = mapped_column(
-        Numeric(12, 2), nullable=False, server_default=text("0")
-    )
-    shipping_cost: Mapped[Decimal] = mapped_column(
-        Numeric(12, 2), nullable=False, server_default=text("0")
-    )
-    total: Mapped[Decimal] = mapped_column(
-        Numeric(12, 2), nullable=False, server_default=text("0")
-    )
-    source_conversation_id: Mapped[Optional[uuid.UUID]] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("conversations.id")
-    )
-    confirmed_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
-    cancelled_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
-    cancel_reason: Mapped[Optional[str]] = mapped_column(Text)
-    notes: Mapped[Optional[str]] = mapped_column(Text)
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=text("now()")
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=text("now()")
-    )
-
-    client_user: Mapped["ClientUser"] = relationship("ClientUser", back_populates="orders", foreign_keys=[client_user_id])
-    lead: Mapped[Optional["Lead"]] = relationship("Lead", back_populates="orders", foreign_keys=[lead_id])
-    source_conversation: Mapped[Optional["Conversation"]] = relationship(
-        "Conversation", foreign_keys=[source_conversation_id], viewonly=True
-    )
-    line_items: Mapped[list["OrderLineItem"]] = relationship(
-        "OrderLineItem", back_populates="order", cascade="all, delete-orphan"
-    )
-
-
-# ---------------------------------------------------------------------------
-# order_line_items
-# ---------------------------------------------------------------------------
-class OrderLineItem(Base):
-    __tablename__ = "order_line_items"
-
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, server_default=text("uuid_generate_v4()")
-    )
-    order_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("orders.id", ondelete="CASCADE"), nullable=False
-    )
-    product_id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), ForeignKey("products.id"), nullable=False
-    )
-    product_name: Mapped[str] = mapped_column(String(255), nullable=False)
-    unit_price: Mapped[Decimal] = mapped_column(Numeric(12, 2), nullable=False)
-    quantity: Mapped[int] = mapped_column(
-        Integer, nullable=False, server_default=text("1")
-    )
-    subtotal: Mapped[Decimal] = mapped_column(Numeric(12, 2), nullable=False)
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), nullable=False, server_default=text("now()")
-    )
-
-    order: Mapped["Order"] = relationship("Order", back_populates="line_items", foreign_keys=[order_id])
-    product: Mapped["Product"] = relationship("Product", back_populates="order_line_items", foreign_keys=[product_id])
 
 
 # ---------------------------------------------------------------------------

--- a/sales_agent_api/app/services/agent_action.py
+++ b/sales_agent_api/app/services/agent_action.py
@@ -1,69 +1,42 @@
-"""Agent action validation and execution service.
+"""Agent action validation service.
 
 After the LLM produces a response, n8n calls this service to:
-  1. Validate the proposed_action against the state machine
-  2. Execute valid business actions (create_lead, propose_order, etc.)
-  3. Validate and apply proposed state transitions
+  1. Persist strategy-relevant extracted_data into conversation.extracted_context
+     (with DAG gates to enforce data order: user_confirmation needs
+     name+phone+address+city; payment_confirmation needs user_confirmation+phone+address)
+  2. Auto-escalate to human_handoff when all purchase data is collected
+  3. Apply a proposed_transition if the LLM sends one (rare)
   4. Persist the outbound message with AI metadata
   5. Write audit log entries
-  6. Return the final response to send to WhatsApp
 """
 from __future__ import annotations
 
 import logging
 import uuid
 from datetime import datetime, timezone
-from decimal import Decimal
 from typing import Optional
 
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.core import (
-    AuditLog,
-    Client,
-    ClientUser,
-    Conversation,
-    Lead,
-    Message,
-    Order,
-    OrderLineItem,
-    Product,
-)
+from app.models.core import AuditLog, Client, Conversation, Message
 from app.services.goal_strategy import GoalStrategyEngine
 from app.services.state_machine import (
-    InvalidActionError,
     InvalidTransitionError,
-    validate_action,
     validate_transition,
 )
 
 logger = logging.getLogger(__name__)
 
-# Actions that don't produce side effects — they pass through without a handler
-INFORMATIONAL_ACTIONS = {
-    "ask_question",
-    "search_products",
-    "greet",
-    "classify_intent",
-    "present_product",
-    "collect_shipping_info",
-    "notify_human",
-    "modify_order",
-}
-
-# Fields from extracted_data that should be persisted to conversation.extracted_context
+# Fields from extracted_data that are persisted to conversation.extracted_context
 # so the GoalStrategyEngine can track progress across turns.
 STRATEGY_FIELDS = {
-    "intent", "product_id", "full_name", "identification_number",
+    "product_id", "full_name", "identification_number",
     "email", "phone", "shipping_address", "shipping_city",
     "user_confirmation", "payment_confirmation",
 }
 
 
-# ---------------------------------------------------------------------------
-# Exceptions
-# ---------------------------------------------------------------------------
 class AgentActionError(Exception):
     pass
 
@@ -76,9 +49,6 @@ class StaleContextError(AgentActionError):
     pass
 
 
-# ---------------------------------------------------------------------------
-# Main service function
-# ---------------------------------------------------------------------------
 async def process_agent_action(
     session: AsyncSession,
     client_id: uuid.UUID,
@@ -93,16 +63,12 @@ async def process_agent_action(
     completion_tokens: Optional[int] = None,
     latency_ms: Optional[int] = None,
 ) -> dict:
-    """Validate and execute an agent proposal.
+    """Validate and persist an agent turn.
 
-    Returns dict with: approved, final_response_text, new_state, side_effects, rejection_reason.
+    Returns dict with: approved, final_response_text, new_state, side_effects.
     """
     extracted_data = extracted_data or {}
     side_effects: list[str] = []
-    approved = True
-    rejection_reason: Optional[str] = None
-    backend_decision_reason: Optional[str] = None
-    action_approved: Optional[bool] = None
     now = datetime.now(timezone.utc)
 
     # --- 1. Load conversation ------------------------------------------------
@@ -127,64 +93,28 @@ async def process_agent_action(
 
     current_state = conversation.state
 
-    # --- 3. Validate + execute proposed_action --------------------------------
-    if proposed_action and proposed_action not in INFORMATIONAL_ACTIONS:
-        try:
-            validate_action(current_state, proposed_action)
-        except InvalidActionError as exc:
-            approved = False
-            rejection_reason = str(exc)
-            backend_decision_reason = f"action_rejected: {exc}"
-            action_approved = False
-            logger.warning("Action rejected: %s", exc)
-        else:
-            action_approved = True
-            result = await _execute_action(
-                session=session,
-                client_id=client_id,
-                conversation=conversation,
-                action=proposed_action,
-                extracted_data=extracted_data,
-                side_effects=side_effects,
-                now=now,
-            )
-            if result.get("rejected"):
-                approved = False
-                rejection_reason = result["reason"]
-                backend_decision_reason = f"business_rule_violation: {result['reason']}"
-                action_approved = False
-            else:
-                backend_decision_reason = f"action_approved: {proposed_action}"
-    elif proposed_action in INFORMATIONAL_ACTIONS:
-        action_approved = True
-        backend_decision_reason = f"informational_action: {proposed_action} (pass-through)"
-
-    # --- 3b. Persist strategy-relevant extracted_data to extracted_context ----
+    # --- 3. Persist extracted_data → extracted_context with DAG gates --------
     if extracted_data:
         strategy_updates = {
             k: v for k, v in extracted_data.items()
             if k in STRATEGY_FIELDS and v
         }
-        # Enforce DAG order: don't accept later-stage fields without prerequisites
         if strategy_updates:
             current_context = conversation.extracted_context or {}
             merged = {**current_context, **strategy_updates}
-            # user_confirmation requires full_name AND shipping_address
+            # user_confirmation requires full_name + phone + shipping_address + shipping_city
             if "user_confirmation" in strategy_updates:
-                if not merged.get("shipping_address") or not merged.get("full_name"):
+                missing = [f for f in ("full_name", "phone", "shipping_address", "shipping_city") if not merged.get(f)]
+                if missing:
                     del strategy_updates["user_confirmation"]
-                    logger.warning(
-                        "Rejected user_confirmation: missing %s",
-                        [f for f in ("full_name", "shipping_address") if not merged.get(f)],
-                    )
-            # payment_confirmation requires user_confirmation AND shipping_address
+                    logger.warning("Rejected user_confirmation: missing %s", missing)
+                    side_effects.append(f"warning:premature_summary_missing_{'+'.join(missing)}")
+            # payment_confirmation requires user_confirmation + phone + shipping_address
             if "payment_confirmation" in strategy_updates:
-                if not merged.get("user_confirmation") or not merged.get("shipping_address"):
+                missing = [f for f in ("user_confirmation", "phone", "shipping_address") if not merged.get(f)]
+                if missing:
                     del strategy_updates["payment_confirmation"]
-                    logger.warning(
-                        "Rejected payment_confirmation: missing %s",
-                        [f for f in ("user_confirmation", "shipping_address") if not merged.get(f)],
-                    )
+                    logger.warning("Rejected payment_confirmation: missing %s", missing)
         if strategy_updates:
             new_context = {**(conversation.extracted_context or {}), **strategy_updates}
             await session.execute(
@@ -195,7 +125,7 @@ async def process_agent_action(
             conversation.extracted_context = new_context
             side_effects.append(f"context_updated:{list(strategy_updates.keys())}")
 
-    # --- 3c. Auto-escalate when all purchase data is collected ----------------
+    # --- 4. Auto-escalate when all purchase data is collected ----------------
     if conversation.state != "human_handoff":
         client_row = await session.execute(
             select(Client).where(Client.id == client_id)
@@ -204,8 +134,7 @@ async def process_agent_action(
         business_rules = (client.business_rules or {}) if client else {}
         collected_data = conversation.extracted_context or {}
         goal = conversation.active_goal or business_rules.get("default_goal", "close_sale")
-        engine = GoalStrategyEngine()
-        directive = engine.compute(goal, collected_data, business_rules)
+        directive = GoalStrategyEngine().compute(goal, collected_data, business_rules)
         if directive.all_complete:
             old_state = conversation.state
             await session.execute(
@@ -235,28 +164,22 @@ async def process_agent_action(
                 conversation.id,
             )
 
-    # --- 4. Validate + apply proposed_transition -----------------------------
-    if proposed_transition and proposed_transition != current_state:
+    # --- 5. Apply proposed_transition (if any) -------------------------------
+    if proposed_transition and proposed_transition != conversation.state:
         try:
-            validate_transition(current_state, proposed_transition)
+            validate_transition(conversation.state, proposed_transition)
         except InvalidTransitionError as exc:
             logger.warning("Transition rejected: %s", exc)
-            side_effects.append(f"transition_rejected:{current_state}→{proposed_transition}")
+            side_effects.append(f"transition_rejected:{conversation.state}→{proposed_transition}")
         else:
-            old_state = current_state
+            old_state = conversation.state
             await session.execute(
                 update(Conversation)
                 .where(Conversation.id == conversation.id)
-                .values(
-                    state=proposed_transition,
-                    previous_state=old_state,
-                    agent_turn_count=Conversation.agent_turn_count + 1,
-                )
+                .values(state=proposed_transition, previous_state=old_state)
             )
             conversation.state = proposed_transition
             side_effects.append(f"state_changed:{old_state}→{proposed_transition}")
-
-            # Audit the state change
             session.add(
                 AuditLog(
                     client_id=client_id,
@@ -268,15 +191,8 @@ async def process_agent_action(
                     new_value={"state": proposed_transition},
                 )
             )
-    else:
-        # Still count the agent turn
-        await session.execute(
-            update(Conversation)
-            .where(Conversation.id == conversation.id)
-            .values(agent_turn_count=Conversation.agent_turn_count + 1)
-        )
 
-    # --- 5. Persist outbound message -----------------------------------------
+    # --- 6. Persist outbound message -----------------------------------------
     out_message = Message(
         conversation_id=conversation.id,
         client_id=client_id,
@@ -288,16 +204,11 @@ async def process_agent_action(
         ai_completion_tokens=completion_tokens,
         ai_latency_ms=latency_ms,
         proposed_action=proposed_action,
-        action_approved=action_approved,
-        proposed_action_payload=extracted_data if proposed_action else None,
         extracted_data=extracted_data,
-        backend_decision_reason=backend_decision_reason,
     )
     session.add(out_message)
-    # Flush first to populate out_message.id before writing audit log
     await session.flush()
 
-    # Audit the agent turn
     session.add(
         AuditLog(
             client_id=client_id,
@@ -307,7 +218,6 @@ async def process_agent_action(
             actor_type="agent",
             new_value={
                 "proposed_action": proposed_action,
-                "action_approved": action_approved,
                 "side_effects": side_effects,
             },
         )
@@ -316,381 +226,9 @@ async def process_agent_action(
     await session.flush()
 
     return {
-        "approved": approved,
+        "approved": True,
         "final_response_text": response_text,
         "new_state": conversation.state,
         "side_effects": side_effects,
-        "rejection_reason": rejection_reason,
+        "rejection_reason": None,
     }
-
-
-# ---------------------------------------------------------------------------
-# Action handlers
-# ---------------------------------------------------------------------------
-async def _execute_action(
-    session: AsyncSession,
-    client_id: uuid.UUID,
-    conversation: Conversation,
-    action: str,
-    extracted_data: dict,
-    side_effects: list[str],
-    now: datetime,
-) -> dict:
-    """Execute a business action. Returns {} on success or {"rejected": True, "reason": ...}."""
-
-    if action == "create_lead":
-        return await _handle_create_lead(
-            session, client_id, conversation, extracted_data, side_effects, now
-        )
-    if action == "update_lead_data":
-        return await _handle_update_lead_data(
-            session, client_id, conversation, extracted_data, side_effects
-        )
-    if action == "propose_order":
-        return await _handle_propose_order(
-            session, client_id, conversation, extracted_data, side_effects, now
-        )
-    if action == "confirm_order":
-        return await _handle_confirm_order(
-            session, client_id, conversation, extracted_data, side_effects, now
-        )
-    if action == "cancel_order":
-        return await _handle_cancel_order(
-            session, client_id, conversation, extracted_data, side_effects, now
-        )
-    if action == "escalate":
-        return await _handle_escalate(
-            session, conversation, extracted_data, side_effects, now
-        )
-
-    # Unknown non-informational action — reject
-    return {"rejected": True, "reason": f"No handler for action '{action}'"}
-
-
-async def _handle_create_lead(
-    session: AsyncSession,
-    client_id: uuid.UUID,
-    conversation: Conversation,
-    extracted_data: dict,
-    side_effects: list[str],
-    now: datetime,
-) -> dict:
-    intent = extracted_data.get("intent")
-    if not intent:
-        return {"rejected": True, "reason": "create_lead requires 'intent' in extracted_data"}
-
-    # Reject if lead already linked to conversation
-    if conversation.lead_id is not None:
-        return {
-            "rejected": True,
-            "reason": "Conversation already has a linked lead. Use update_lead_data instead.",
-        }
-
-    lead = Lead(
-        client_id=client_id,
-        client_user_id=conversation.client_user_id,
-        status="new",
-        intent=intent,
-        qualification_data=extracted_data,
-        source_conversation_id=conversation.id,
-    )
-    session.add(lead)
-    await session.flush()
-
-    # Link lead to conversation
-    await session.execute(
-        update(Conversation)
-        .where(Conversation.id == conversation.id)
-        .values(lead_id=lead.id)
-    )
-    conversation.lead_id = lead.id
-
-    session.add(
-        AuditLog(
-            client_id=client_id,
-            event_type="lead_created",
-            entity_type="lead",
-            entity_id=lead.id,
-            actor_type="agent",
-            new_value={"status": "new", "intent": intent},
-        )
-    )
-    side_effects.append(f"lead_created:{lead.id}")
-    return {}
-
-
-async def _handle_update_lead_data(
-    session: AsyncSession,
-    client_id: uuid.UUID,
-    conversation: Conversation,
-    extracted_data: dict,
-    side_effects: list[str],
-) -> dict:
-    if conversation.lead_id is None:
-        return {"rejected": True, "reason": "No lead linked to conversation"}
-
-    lead_row = await session.execute(
-        select(Lead).where(Lead.id == conversation.lead_id, Lead.client_id == client_id)
-    )
-    lead: Optional[Lead] = lead_row.scalar_one_or_none()
-    if lead is None:
-        return {"rejected": True, "reason": "Lead not found"}
-
-    old_data = dict(lead.qualification_data or {})
-    merged = {**old_data, **extracted_data}
-
-    await session.execute(
-        update(Lead)
-        .where(Lead.id == lead.id)
-        .values(qualification_data=merged)
-    )
-
-    side_effects.append(f"lead_updated:{lead.id}")
-    return {}
-
-
-async def _handle_propose_order(
-    session: AsyncSession,
-    client_id: uuid.UUID,
-    conversation: Conversation,
-    extracted_data: dict,
-    side_effects: list[str],
-    now: datetime,
-) -> dict:
-    items = extracted_data.get("items", [])
-    if not items:
-        return {"rejected": True, "reason": "propose_order requires 'items' in extracted_data"}
-
-    order = Order(
-        client_id=client_id,
-        client_user_id=conversation.client_user_id,
-        lead_id=conversation.lead_id,
-        status="draft",
-        source_conversation_id=conversation.id,
-    )
-    session.add(order)
-    await session.flush()
-
-    subtotal = Decimal("0")
-    valid_items = 0
-
-    for item in items:
-        product_id = item.get("product_id")
-        quantity = max(1, int(item.get("quantity", 1)))
-
-        if not product_id:
-            continue
-
-        prod_row = await session.execute(
-            select(Product).where(
-                Product.id == uuid.UUID(str(product_id)),
-                Product.client_id == client_id,
-                Product.is_available.is_(True),
-            )
-        )
-        product: Optional[Product] = prod_row.scalar_one_or_none()
-        if product is None:
-            logger.warning("Product %s not found or unavailable — skipping line item", product_id)
-            continue
-
-        line_subtotal = product.price * quantity
-        line_item = OrderLineItem(
-            order_id=order.id,
-            product_id=product.id,
-            product_name=product.name,
-            unit_price=product.price,  # price from catalog, never from agent
-            quantity=quantity,
-            subtotal=line_subtotal,
-        )
-        session.add(line_item)
-        subtotal += line_subtotal
-        valid_items += 1
-
-    if valid_items == 0:
-        # Roll back: delete the order shell
-        await session.delete(order)
-        return {"rejected": True, "reason": "No valid products in order"}
-
-    await session.execute(
-        update(Order)
-        .where(Order.id == order.id)
-        .values(subtotal=subtotal, total=subtotal)
-    )
-
-    # Link order to conversation
-    await session.execute(
-        update(Conversation)
-        .where(Conversation.id == conversation.id)
-        .values(order_id=order.id)
-    )
-    conversation.order_id = order.id
-
-    # Also update extracted_context with the order_id so strategy engine sees it
-    new_context = {**(conversation.extracted_context or {}), "order_id": str(order.id)}
-    await session.execute(
-        update(Conversation)
-        .where(Conversation.id == conversation.id)
-        .values(extracted_context=new_context)
-    )
-
-    session.add(
-        AuditLog(
-            client_id=client_id,
-            event_type="order_created",
-            entity_type="order",
-            entity_id=order.id,
-            actor_type="agent",
-            new_value={"status": "draft", "subtotal": str(subtotal), "items": valid_items},
-        )
-    )
-    side_effects.append(f"order_created:{order.id}")
-    return {}
-
-
-async def _handle_confirm_order(
-    session: AsyncSession,
-    client_id: uuid.UUID,
-    conversation: Conversation,
-    extracted_data: dict,
-    side_effects: list[str],
-    now: datetime,
-) -> dict:
-    if conversation.order_id is None:
-        return {"rejected": True, "reason": "No order linked to conversation"}
-
-    order_row = await session.execute(
-        select(Order).where(Order.id == conversation.order_id, Order.client_id == client_id)
-    )
-    order: Optional[Order] = order_row.scalar_one_or_none()
-    if order is None:
-        return {"rejected": True, "reason": "Order not found"}
-
-    # Validate confirmation requirements
-    missing = []
-    if not order.shipping_name and not extracted_data.get("shipping_name"):
-        missing.append("shipping_name")
-    if not order.shipping_address and not extracted_data.get("shipping_address"):
-        missing.append("shipping_address")
-    if not extracted_data.get("user_confirmation"):
-        missing.append("user_confirmation")
-
-    # Check line items
-    items_row = await session.execute(
-        select(OrderLineItem).where(OrderLineItem.order_id == order.id)
-    )
-    if not items_row.scalars().all():
-        missing.append("order_line_items")
-
-    if missing:
-        return {
-            "rejected": True,
-            "reason": f"Cannot confirm order. Missing: {', '.join(missing)}",
-        }
-
-    updates: dict = {"status": "confirmed", "confirmed_at": now}
-    if extracted_data.get("shipping_name"):
-        updates["shipping_name"] = extracted_data["shipping_name"]
-    if extracted_data.get("shipping_address"):
-        updates["shipping_address"] = extracted_data["shipping_address"]
-    if extracted_data.get("shipping_city"):
-        updates["shipping_city"] = extracted_data["shipping_city"]
-    if extracted_data.get("shipping_phone"):
-        updates["shipping_phone"] = extracted_data["shipping_phone"]
-
-    await session.execute(update(Order).where(Order.id == order.id).values(**updates))
-
-    session.add(
-        AuditLog(
-            client_id=client_id,
-            event_type="order_confirmed",
-            entity_type="order",
-            entity_id=order.id,
-            actor_type="agent",
-            old_value={"status": "draft"},
-            new_value={"status": "confirmed"},
-        )
-    )
-    side_effects.append(f"order_confirmed:{order.id}")
-    return {}
-
-
-async def _handle_cancel_order(
-    session: AsyncSession,
-    client_id: uuid.UUID,
-    conversation: Conversation,
-    extracted_data: dict,
-    side_effects: list[str],
-    now: datetime,
-) -> dict:
-    if conversation.order_id is None:
-        return {"rejected": True, "reason": "No order linked to conversation"}
-
-    order_row = await session.execute(
-        select(Order).where(Order.id == conversation.order_id, Order.client_id == client_id)
-    )
-    order: Optional[Order] = order_row.scalar_one_or_none()
-    if order is None:
-        return {"rejected": True, "reason": "Order not found"}
-
-    if order.status not in ("draft", "confirmed"):
-        return {
-            "rejected": True,
-            "reason": f"Cannot cancel order in status '{order.status}'",
-        }
-
-    cancel_reason = extracted_data.get("cancel_reason", "Cancelled by agent")
-    await session.execute(
-        update(Order)
-        .where(Order.id == order.id)
-        .values(status="cancelled", cancelled_at=now, cancel_reason=cancel_reason)
-    )
-
-    session.add(
-        AuditLog(
-            client_id=client_id,
-            event_type="order_cancelled",
-            entity_type="order",
-            entity_id=order.id,
-            actor_type="agent",
-            old_value={"status": order.status},
-            new_value={"status": "cancelled", "cancel_reason": cancel_reason},
-        )
-    )
-    side_effects.append(f"order_cancelled:{order.id}")
-    return {}
-
-
-async def _handle_escalate(
-    session: AsyncSession,
-    conversation: Conversation,
-    extracted_data: dict,
-    side_effects: list[str],
-    now: datetime,
-) -> dict:
-    reason = extracted_data.get("escalation_reason", "Escalated by agent")
-    old_state = conversation.state
-
-    await session.execute(
-        update(Conversation)
-        .where(Conversation.id == conversation.id)
-        .values(
-            state="human_handoff",
-            previous_state=old_state,
-            escalation_reason=reason,
-        )
-    )
-    conversation.state = "human_handoff"
-
-    session.add(
-        AuditLog(
-            client_id=conversation.client_id,
-            event_type="escalated",
-            entity_type="conversation",
-            entity_id=conversation.id,
-            actor_type="agent",
-            old_value={"state": old_state},
-            new_value={"state": "human_handoff", "reason": reason},
-        )
-    )
-    side_effects.append(f"escalated:{reason[:50]}")
-    return {}

--- a/sales_agent_api/app/services/goal_strategy.py
+++ b/sales_agent_api/app/services/goal_strategy.py
@@ -84,19 +84,17 @@ class StrategyDirective:
 # Goal definitions
 # ---------------------------------------------------------------------------
 def _build_close_sale_checkpoints(business_rules: dict) -> list[Checkpoint]:
-    """Build the close_sale DAG, applying client-specific overrides."""
+    """Build the close_sale DAG, applying client-specific overrides.
+
+    Intent is implicit: if the customer reaches product_matched, they expressed
+    buying interest. No separate intent_identified checkpoint.
+    """
     checkpoints = [
-        Checkpoint(
-            name="intent_identified",
-            label="Intent identified",
-            required_fields=["intent"],
-            blocked_by=[],
-        ),
         Checkpoint(
             name="product_matched",
             label="Product matched",
             required_fields=["product_id"],
-            blocked_by=["intent_identified"],
+            blocked_by=[],
         ),
     ]
 
@@ -112,11 +110,11 @@ def _build_close_sale_checkpoints(business_rules: dict) -> list[Checkpoint]:
                 name="lead_qualified",
                 label="Lead qualified",
                 required_fields=lead_fields,
-                blocked_by=["intent_identified"],
+                blocked_by=[],
             )
         )
 
-    shipping_blocked_by = ["lead_qualified"] if not business_rules.get("skip_lead_qualification", False) else ["intent_identified"]
+    shipping_blocked_by = ["lead_qualified"] if not business_rules.get("skip_lead_qualification", False) else []
     checkpoints.append(
         Checkpoint(
             name="shipping_info_collected",
@@ -128,19 +126,10 @@ def _build_close_sale_checkpoints(business_rules: dict) -> list[Checkpoint]:
 
     checkpoints.append(
         Checkpoint(
-            name="order_created",
-            label="Order created",
-            required_fields=["order_id"],
-            blocked_by=["product_matched", "shipping_info_collected"],
-        )
-    )
-
-    checkpoints.append(
-        Checkpoint(
             name="user_confirmed",
             label="User confirmed",
             required_fields=["user_confirmation"],
-            blocked_by=["order_created"],
+            blocked_by=["product_matched", "shipping_info_collected"],
         )
     )
 
@@ -282,7 +271,6 @@ class GoalStrategyEngine:
 
         field = missing_fields[0]
         prompts = {
-            "intent": "Try to understand what the customer is looking for.",
             "product_id": "Help the customer choose a product from the catalog.",
             "full_name": "Try to learn the customer's name.",
             "identification_number": "Ask for the customer's ID number.",
@@ -290,8 +278,7 @@ class GoalStrategyEngine:
             "phone": "Try to learn the customer's phone number for the carrier.",
             "shipping_address": "Try to learn the full delivery address (neighborhood, street, number, apartment).",
             "shipping_city": "Try to learn the customer's city.",
-            "order_id": "Present an order summary so the backend can create the order.",
-            "user_confirmation": "Ask the customer to confirm the order.",
+            "user_confirmation": "Present an order summary with all the collected data and ask the customer to confirm.",
             "payment_confirmation": "Share payment methods and ask the customer to send payment receipt once paid.",
         }
         return prompts.get(field, f"Ask for the customer's {field.replace('_', ' ')}.")

--- a/sales_agent_api/app/services/ingest.py
+++ b/sales_agent_api/app/services/ingest.py
@@ -35,7 +35,6 @@ from app.models.core import (
 )
 from app.services.goal_strategy import GoalStrategyEngine
 from app.services.prompt_context import format_business_context, format_conversation_summary
-from app.services.state_machine import get_available_actions
 
 logger = logging.getLogger(__name__)
 
@@ -332,7 +331,6 @@ async def ingest_message(
             "missing_fields": directive.missing_fields,
         },
         "strategy_version": new_strategy_version,
-        "available_actions": get_available_actions(conversation.state),
         "client_config": {
             "system_prompt_template": client.system_prompt_template or "",
             "ai_model": client.ai_model,

--- a/sales_agent_api/app/services/prompt_context.py
+++ b/sales_agent_api/app/services/prompt_context.py
@@ -29,13 +29,14 @@ def format_business_context(
         for p in product_catalog:
             price = _format_price(p.get("price", 0), currency)
             desc = p.get("ai_description") or p.get("description") or ""
-            lines.append(f"- {p['name']} ({p.get('sku', 'N/A')}): {price}")
+            lines.append(f"- {p['name']} (id: {p['id']}, sku: {p.get('sku', 'N/A')}): {price}")
             if desc:
                 lines.append(f"  {desc}")
             if p.get("image_url"):
                 lines.append(f"  image_url: {p['image_url']}")
         lines.append("Only mention the price if the customer asks or shows real interest.")
         lines.append("You can ONLY sell products listed above. NEVER invent or mention products not in this catalog.")
+        lines.append("PRODUCT_ID RULE: extracted_data.product_id MUST be the 'id' UUID shown above, NEVER the sku.")
         if any(p.get("image_url") for p in product_catalog):
             lines.append("IMAGES: If the customer asks for a photo/image of a product, you MUST set extracted_data.send_image_url to the product's image_url shown above. The system will send the image automatically.")
         sections.append("\n".join(lines))
@@ -130,8 +131,8 @@ def format_conversation_summary(
         known.append("city: on file")
 
     # From extracted_context (conversation-level data)
-    for field in ("intent", "product_id", "full_name", "shipping_address",
-                  "shipping_city", "order_id", "user_confirmation",
+    for field in ("product_id", "full_name", "phone", "shipping_address",
+                  "shipping_city", "user_confirmation",
                   "payment_confirmation"):
         value = extracted_context.get(field)
         if value:

--- a/sales_agent_api/app/services/state_machine.py
+++ b/sales_agent_api/app/services/state_machine.py
@@ -1,61 +1,22 @@
-"""Conversation state machine.
+"""Conversation state machine — 3 states.
 
-Defines valid states, transitions, and actions per state.
-Pure Python — no database queries, no LLM calls.
+States used in practice:
+  - active:        normal conversation
+  - human_handoff: escalated to a human operator
+  - closed:        terminated
+
+Pure Python — no DB, no I/O.
 """
 from __future__ import annotations
 
 
-# ---------------------------------------------------------------------------
-# State definitions
-# ---------------------------------------------------------------------------
-STATES: dict[str, dict] = {
-    "idle": {
-        "transitions": ["active", "closed"],
-        "actions": ["greet", "classify_intent"],
-    },
-    "active": {
-        "transitions": ["qualifying", "selling", "human_handoff", "idle", "closed"],
-        "actions": ["classify_intent", "ask_question", "search_products", "escalate"],
-    },
-    "qualifying": {
-        "transitions": ["selling", "active", "human_handoff", "closed"],
-        "actions": ["ask_question", "create_lead", "update_lead_data", "escalate"],
-    },
-    "selling": {
-        "transitions": ["ordering", "qualifying", "active", "human_handoff", "closed"],
-        "actions": [
-            "search_products",
-            "present_product",
-            "propose_order",
-            "ask_question",
-            "escalate",
-        ],
-    },
-    "ordering": {
-        "transitions": ["selling", "human_handoff", "closed"],
-        "actions": [
-            "collect_shipping_info",
-            "confirm_order",
-            "modify_order",
-            "cancel_order",
-            "escalate",
-        ],
-    },
-    "human_handoff": {
-        "transitions": ["active", "closed"],
-        "actions": ["notify_human"],
-    },
-    "closed": {
-        "transitions": [],
-        "actions": [],
-    },
+STATES: dict[str, list[str]] = {
+    "active":        ["human_handoff", "closed"],
+    "human_handoff": ["active", "closed"],
+    "closed":        [],
 }
 
 
-# ---------------------------------------------------------------------------
-# Exceptions
-# ---------------------------------------------------------------------------
 class StateMachineError(Exception):
     pass
 
@@ -64,52 +25,24 @@ class InvalidTransitionError(StateMachineError):
     def __init__(self, current: str, target: str) -> None:
         super().__init__(
             f"Transition '{current}' → '{target}' is not allowed. "
-            f"Valid targets: {STATES.get(current, {}).get('transitions', [])}"
+            f"Valid targets: {STATES.get(current, [])}"
         )
         self.current = current
         self.target = target
-
-
-class InvalidActionError(StateMachineError):
-    def __init__(self, state: str, action: str) -> None:
-        super().__init__(
-            f"Action '{action}' is not allowed in state '{state}'. "
-            f"Valid actions: {STATES.get(state, {}).get('actions', [])}"
-        )
-        self.state = state
-        self.action = action
 
 
 class UnknownStateError(StateMachineError):
     pass
 
 
-# ---------------------------------------------------------------------------
-# Validators
-# ---------------------------------------------------------------------------
 def validate_transition(current: str, target: str) -> None:
     """Raise InvalidTransitionError if the transition is not allowed."""
     if current not in STATES:
         raise UnknownStateError(f"Unknown current state: '{current}'")
     if target not in STATES:
         raise UnknownStateError(f"Unknown target state: '{target}'")
-    if target not in STATES[current]["transitions"]:
+    if target not in STATES[current]:
         raise InvalidTransitionError(current, target)
-
-
-def validate_action(state: str, action: str) -> None:
-    """Raise InvalidActionError if the action is not allowed in the given state."""
-    if state not in STATES:
-        raise UnknownStateError(f"Unknown state: '{state}'")
-    if action not in STATES[state]["actions"]:
-        raise InvalidActionError(state, action)
-
-
-def get_available_actions(state: str) -> list[str]:
-    """Return the list of actions available in the given state."""
-    if state not in STATES:
-        raise UnknownStateError(f"Unknown state: '{state}'")
-    return list(STATES[state]["actions"])
 
 
 def is_valid_state(state: str) -> bool:

--- a/tests/services/test_goal_strategy.py
+++ b/tests/services/test_goal_strategy.py
@@ -1,11 +1,13 @@
-"""18 tests for GoalStrategyEngine.
+"""Tests for GoalStrategyEngine (post-simplification).
+
+The close_sale DAG no longer has `intent_identified` (inferred from product_matched)
+nor `order_created` (orders are not materialized in DB — payment handoff is manual).
 
 All pure Python — no database, no network, no LLM calls.
 """
 import sys
 import os
 
-# Add the sales_agent_api directory to the path so imports work
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../sales_agent_api"))
 
 import pytest
@@ -21,37 +23,37 @@ engine = GoalStrategyEngine()
 
 
 # ---------------------------------------------------------------------------
-# 1–7: close_sale DAG progression
+# close_sale DAG progression
 # ---------------------------------------------------------------------------
 
-def test_01_empty_data_targets_intent():
-    """With no data collected, engine should target intent_identified."""
+def test_01_empty_data_targets_product():
+    """With no data collected, engine targets product_matched."""
     d = engine.compute("close_sale", {})
-    assert d.current_checkpoint == "intent_identified"
-    assert "intent" in d.missing_fields
+    assert d.current_checkpoint == "product_matched"
+    assert "product_id" in d.missing_fields
     assert d.progress_pct == 0
     assert not d.all_complete
 
 
-def test_02_intent_set_targets_product():
-    """With intent known, next checkpoint should be product_matched."""
-    d = engine.compute("close_sale", {"intent": "comprar café"})
-    assert d.current_checkpoint == "product_matched"
-    assert "product_id" in d.missing_fields
-
-
-def test_03_intent_and_product_targets_lead_qualified():
-    """With intent + product, next target is lead_qualified (full_name)."""
-    d = engine.compute("close_sale", {"intent": "comprar", "product_id": "abc"})
+def test_02_product_set_targets_lead_qualified():
+    """With product known, next checkpoint is lead_qualified."""
+    d = engine.compute("close_sale", {"product_id": "abc"})
     assert d.current_checkpoint == "lead_qualified"
     assert "full_name" in d.missing_fields
 
 
+def test_03_product_and_name_still_needs_phone():
+    """With product + name but no phone, still on lead_qualified."""
+    d = engine.compute("close_sale", {"product_id": "abc", "full_name": "Juan"})
+    assert d.current_checkpoint == "lead_qualified"
+    assert "phone" in d.missing_fields
+
+
 def test_04_qualified_targets_shipping():
-    """With intent + product + name, target shipping_info_collected."""
+    """With product + name + phone, target shipping_info_collected."""
     d = engine.compute(
         "close_sale",
-        {"intent": "comprar", "product_id": "abc", "full_name": "Juan", "phone": "3001234567"},
+        {"product_id": "abc", "full_name": "Juan", "phone": "3001234567"},
     )
     assert d.current_checkpoint == "shipping_info_collected"
     assert "shipping_address" in d.missing_fields or "shipping_city" in d.missing_fields
@@ -62,9 +64,9 @@ def test_05_shipping_address_but_missing_city():
     d = engine.compute(
         "close_sale",
         {
-            "intent": "comprar",
             "product_id": "abc",
-            "full_name": "Juan", "phone": "3001234567",
+            "full_name": "Juan",
+            "phone": "3001234567",
             "shipping_address": "Calle 10",
         },
     )
@@ -72,54 +74,32 @@ def test_05_shipping_address_but_missing_city():
     assert "shipping_city" in d.missing_fields
 
 
-def test_06_full_shipping_targets_order_created():
-    """With all shipping info, target order_created."""
+def test_06_full_shipping_targets_user_confirmed():
+    """With all shipping info + lead, target user_confirmed (summary stage)."""
     d = engine.compute(
         "close_sale",
         {
-            "intent": "comprar",
             "product_id": "abc",
-            "full_name": "Juan", "phone": "3001234567",
+            "full_name": "Juan",
+            "phone": "3001234567",
             "shipping_address": "Calle 10",
             "shipping_city": "Manizales",
-        },
-    )
-    assert d.current_checkpoint == "order_created"
-    assert "order_id" in d.missing_fields
-
-
-def test_07_order_created_targets_user_confirmed():
-    """With order_id set, target user_confirmed."""
-    d = engine.compute(
-        "close_sale",
-        {
-            "intent": "comprar",
-            "product_id": "abc",
-            "full_name": "Juan", "phone": "3001234567",
-            "shipping_address": "Calle 10",
-            "shipping_city": "Manizales",
-            "order_id": "order-uuid",
         },
     )
     assert d.current_checkpoint == "user_confirmed"
     assert "user_confirmation" in d.missing_fields
 
 
-# ---------------------------------------------------------------------------
-# 8: all complete
-# ---------------------------------------------------------------------------
-
-def test_07b_user_confirmed_targets_payment():
+def test_07_user_confirmed_targets_payment():
     """With user_confirmation set, target payment_confirmed."""
     d = engine.compute(
         "close_sale",
         {
-            "intent": "comprar",
             "product_id": "abc",
-            "full_name": "Juan", "phone": "3001234567",
+            "full_name": "Juan",
+            "phone": "3001234567",
             "shipping_address": "Calle 10",
             "shipping_city": "Manizales",
-            "order_id": "order-uuid",
             "user_confirmation": True,
         },
     )
@@ -127,17 +107,20 @@ def test_07b_user_confirmed_targets_payment():
     assert "payment_confirmation" in d.missing_fields
 
 
+# ---------------------------------------------------------------------------
+# All complete
+# ---------------------------------------------------------------------------
+
 def test_08_all_complete_returns_100():
     """When all fields are present, progress should be 100% and all_complete=True."""
     d = engine.compute(
         "close_sale",
         {
-            "intent": "comprar",
             "product_id": "abc",
-            "full_name": "Juan", "phone": "3001234567",
+            "full_name": "Juan",
+            "phone": "3001234567",
             "shipping_address": "Calle 10",
             "shipping_city": "Manizales",
-            "order_id": "order-uuid",
             "user_confirmation": True,
             "payment_confirmation": True,
         },
@@ -148,17 +131,16 @@ def test_08_all_complete_returns_100():
 
 
 # ---------------------------------------------------------------------------
-# 9–11: business rule overrides
+# Business rule overrides
 # ---------------------------------------------------------------------------
 
 def test_09_skip_lead_qualification_jumps_to_shipping():
     """skip_lead_qualification=True should remove lead_qualified checkpoint."""
     d = engine.compute(
         "close_sale",
-        {"intent": "comprar", "product_id": "abc"},
+        {"product_id": "abc"},
         business_rules={"skip_lead_qualification": True},
     )
-    # Should skip lead_qualified and go straight to shipping
     assert d.current_checkpoint == "shipping_info_collected"
     assert "full_name" not in d.missing_fields
 
@@ -167,10 +149,9 @@ def test_10_require_id_number_adds_field():
     """require_id_number=True should add identification_number to lead_qualified."""
     d = engine.compute(
         "close_sale",
-        {"intent": "comprar", "product_id": "abc"},
+        {"product_id": "abc"},
         business_rules={"require_id_number": True},
     )
-    # We're at lead_qualified — identification_number should be required
     assert d.current_checkpoint == "lead_qualified"
     assert "identification_number" in d.missing_fields
 
@@ -179,7 +160,7 @@ def test_11_require_email_adds_field():
     """require_email=True should add email to lead_qualified fields."""
     d = engine.compute(
         "close_sale",
-        {"intent": "comprar", "product_id": "abc"},
+        {"product_id": "abc"},
         business_rules={"require_email": True},
     )
     assert d.current_checkpoint == "lead_qualified"
@@ -187,7 +168,7 @@ def test_11_require_email_adds_field():
 
 
 # ---------------------------------------------------------------------------
-# 12–14: progress percentages
+# Progress percentages
 # ---------------------------------------------------------------------------
 
 def test_12_progress_0_at_start():
@@ -195,11 +176,14 @@ def test_12_progress_0_at_start():
     assert d.progress_pct == 0
 
 
-def test_13_progress_increases_linearly():
+def test_13_progress_increases_as_checkpoints_complete():
     """Progress % should increase as checkpoints complete."""
     d0 = engine.compute("close_sale", {})
-    d1 = engine.compute("close_sale", {"intent": "comprar"})
-    d2 = engine.compute("close_sale", {"intent": "comprar", "product_id": "abc"})
+    d1 = engine.compute("close_sale", {"product_id": "abc"})
+    d2 = engine.compute(
+        "close_sale",
+        {"product_id": "abc", "full_name": "Juan", "phone": "3001234567"},
+    )
     assert d0.progress_pct < d1.progress_pct
     assert d1.progress_pct < d2.progress_pct
 
@@ -208,12 +192,11 @@ def test_14_progress_100_when_all_complete():
     d = engine.compute(
         "close_sale",
         {
-            "intent": "comprar",
             "product_id": "abc",
-            "full_name": "Juan", "phone": "3001234567",
+            "full_name": "Juan",
+            "phone": "3001234567",
             "shipping_address": "Calle 10",
             "shipping_city": "Manizales",
-            "order_id": "order-uuid",
             "user_confirmation": True,
             "payment_confirmation": True,
         },
@@ -222,7 +205,7 @@ def test_14_progress_100_when_all_complete():
 
 
 # ---------------------------------------------------------------------------
-# 15–17: to_prompt() formatting
+# to_prompt() formatting
 # ---------------------------------------------------------------------------
 
 def test_15_prompt_contains_progress():
@@ -244,11 +227,31 @@ def test_17_prompt_lists_missing_fields():
     d = engine.compute("close_sale", {})
     prompt = d.to_prompt()
     assert "NEXT INFO NEEDED" in prompt
-    assert "intent" in prompt
+    assert "product_id" in prompt
 
 
 def test_18_prompt_answers_customer_first():
-    d = engine.compute("close_sale", {"intent": "comprar"})
+    d = engine.compute("close_sale", {"product_id": "abc"})
     prompt = d.to_prompt()
     assert "warm, natural conversation" in prompt
     assert "Do NOT mention or push toward the next step" in prompt
+
+
+def test_19_no_intent_checkpoint_remains():
+    """Regression: intent_identified should no longer be a checkpoint."""
+    d = engine.compute("close_sale", {})
+    assert d.current_checkpoint != "intent_identified"
+    # And a large collected_data without `intent` should still reach all_complete
+    d2 = engine.compute(
+        "close_sale",
+        {
+            "product_id": "abc",
+            "full_name": "Juan",
+            "phone": "3001234567",
+            "shipping_address": "Calle 10",
+            "shipping_city": "Manizales",
+            "user_confirmation": True,
+            "payment_confirmation": True,
+        },
+    )
+    assert d2.all_complete

--- a/tests/services/test_prompt_context.py
+++ b/tests/services/test_prompt_context.py
@@ -120,9 +120,9 @@ def test_summary_with_display_name():
 def test_summary_with_extracted_context():
     result = format_conversation_summary(
         {},
-        {"intent": "comprar café", "full_name": "Juan Pérez", "shipping_city": "Manizales"},
+        {"product_id": "abc-uuid", "full_name": "Juan Pérez", "shipping_city": "Manizales"},
     )
-    assert "intent: comprar café" in result
+    assert "product_id: abc-uuid" in result
     assert "full_name: Juan Pérez" in result
     assert "shipping_city: Manizales" in result
 
@@ -140,10 +140,10 @@ def test_summary_with_profile_flags():
 def test_summary_combines_profile_and_context():
     result = format_conversation_summary(
         {"display_name": "Juan", "has_full_name": True},
-        {"intent": "comprar", "product_id": "abc"},
+        {"product_id": "abc", "phone": "3001234567"},
     )
     assert "Juan" in result
-    assert "intent: comprar" in result
+    assert "phone: 3001234567" in result
     assert "product_id: abc" in result
 
 


### PR DESCRIPTION
## Summary

Dos fases en un PR (dos commits separados). Arregla los 5 bugs observados en la conversación del 19-abr 22:16-22:24 y elimina ~1000 LOC de código muerto.

**Commits:**
- `cec5ce0` — Fase 2: bugs críticos de flujo de datos
- `844d5a2` — Fase 3: simplificación + UX tono (tuteo cálido, sin regionalismos fuertes)

**Net LOC:** +134 / -827 en código de servicios

## Fase 2 — Bugs arreglados

1. **`intent` nunca se capturaba** → eliminado checkpoint `intent_identified` (implícito una vez hay `product_id`).
2. **`product_id` guardaba SKU "CAFE-001" en vez de UUID** → catálogo se renderiza con `id: <uuid>, sku: <sku>` + regla explícita en system_prompt.
3. **Resumen prematuro sin todos los datos** → DAG gate en `agent_action` ahora exige `full_name + phone + shipping_address + shipping_city` antes de `user_confirmation`.
4. **Doble envío del resumen** → regla en system_prompt: si ya enviaste resumen y solo faltaba un dato, solo confirma brevemente.
5. **Auto-escalate nunca disparaba** → DAG simplificado (sin `intent_identified` ni `order_created` redundante).

## Fase 3 — Simplificación

- **State machine**: 7 estados → 3 (`active`, `human_handoff`, `closed`). Eliminados `idle`, `qualifying`, `selling`, `ordering` (nunca usados).
- **agent_action.py**: 696 → 205 LOC. Eliminados 6 handlers muertos (`_handle_create_lead`, `_handle_update_lead_data`, `_handle_propose_order`, `_handle_confirm_order`, `_handle_cancel_order`, `_handle_escalate`), `_execute_action`, `validate_action`, `INFORMATIONAL_ACTIONS`.
- **Modelos ORM**: eliminadas clases `Lead`, `Order`, `OrderLineItem` y las columnas `Conversation.lead_id`, `Conversation.order_id`, `Conversation.agent_turn_count` del ORM. **Las tablas y columnas en PostgreSQL siguen intactas** — se pueden reintroducir si se necesita remarketing estructurado.
- **`available_actions`** eliminado del response de `/ingest/message` (nadie lo leía).
- **System prompt nuevo**: tuteo cálido, respetuoso, humano, sin \"sumercé\" ni regionalismos fuertes. Incluye las nuevas reglas de UUID y no-duplicar-resumen.

## Migrations

**No hay nada que correr.** Schema de DB sin cambios. Solo se removieron mapeos ORM; las tablas físicas (`leads`, `orders`, `order_line_items`) y columnas (`lead_id`, `order_id`, `agent_turn_count`) siguen en la DB para uso futuro si se necesita.

## Test plan

- [x] `pytest tests/services/` → 37/37 verdes localmente
- [x] `python -c 'from app.main import app'` importa limpio
- [ ] Tras merge + deploy: mensaje de prueba en WhatsApp — cliente pide café, da datos en orden variado; resumen SOLO cuando están los 4 campos requeridos
- [ ] Tras completar pago: `conversation.state` pasa a `human_handoff` vía auto-escalate
- [ ] DB: `extracted_context.product_id` contiene UUID, nunca SKU
- [ ] Tono del agente se siente cálido/moderno sin caer en folksy