### PR TITLE
docs(readme): reescribir para reflejar el estado post-refactor + limitaciones

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,88 +1,53 @@
 # Sales AI Agent — Backend
 
-Un backend de ventas por WhatsApp donde **la inteligencia artificial conversa, pero el backend gobierna**. El agente decide las palabras; el backend decide la estrategia, valida cada acción y protege las reglas de negocio.
+Backend de ventas por WhatsApp donde **la IA conversa y el backend gobierna**. El LLM escribe las palabras; el backend decide la estrategia del turno, valida qué datos se pueden guardar y cuándo, y garantiza que el flujo de compra respete el orden correcto.
 
 ---
 
 ## Tabla de contenidos
 
 1. [¿Qué problema resuelve?](#qué-problema-resuelve)
-2. [La innovación: tres capas de control](#la-innovación-tres-capas-de-control)
-3. [Arquitectura: el patrón de dos llamadas](#arquitectura-el-patrón-de-dos-llamadas)
-4. [Flujo de una conversación completa](#flujo-de-una-conversación-completa)
-5. [Los endpoints en detalle](#los-endpoints-en-detalle)
-6. [Ejemplo concreto: vender un café](#ejemplo-concreto-vender-un-café)
-7. [El GoalStrategyEngine explicado](#el-goalstrategyengine-explicado)
-8. [La máquina de estados](#la-máquina-de-estados)
+2. [Cómo funciona: el patrón de dos llamadas](#cómo-funciona-el-patrón-de-dos-llamadas)
+3. [El GoalStrategyEngine](#el-goalstrategyengine)
+4. [DAG gates en `agent_action`](#dag-gates-en-agent_action)
+5. [Máquina de estados de conversación](#máquina-de-estados-de-conversación)
+6. [Endpoints](#endpoints)
+7. [Ejemplo concreto end-to-end](#ejemplo-concreto-end-to-end)
+8. [Limitaciones conocidas](#limitaciones-conocidas)
 9. [Decisiones técnicas](#decisiones-técnicas)
 10. [Estructura del proyecto](#estructura-del-proyecto)
-11. [Cómo correr el proyecto localmente](#cómo-correr-el-proyecto-localmente)
+11. [Correr localmente](#correr-localmente)
+12. [Producción](#producción)
 
 ---
 
 ## ¿Qué problema resuelve?
 
-La mayoría de los chatbots de ventas funcionan así:
+Un chatbot típico de WhatsApp funciona así:
 
 ```
 WhatsApp → LLM → respuesta
 ```
 
-Simple, pero frágil. El LLM puede inventar precios, saltarse pasos del proceso de venta, crear pedidos sin datos de envío, o simplemente divagar. No hay forma de garantizar que el agente siga las reglas del negocio porque esas reglas viven en el prompt, y los prompts no son código.
+Simple, pero frágil: el LLM puede saltar pasos, pedir comprobante de pago sin haber confirmado nada, inventar precios, o confundirse entre turnos. El prompt ayuda pero no es código — no hay garantías.
 
-Este backend introduce una capa intermedia:
+Este backend se sienta en el medio:
 
 ```
-WhatsApp → Backend → LLM → Backend → WhatsApp
+WhatsApp → n8n → Backend → LLM → Backend → WhatsApp
 ```
 
-El backend le dice al LLM **qué perseguir** en cada turno (no solo qué pasó). Luego valida **cada propuesta** del LLM antes de ejecutarla. El LLM nunca puede crear un pedido con precios inventados, saltar el paso de recolección de datos, ni confirmar una orden sin dirección de envío — no porque se lo prohibamos en el prompt, sino porque esas acciones no existen en el backend a menos que se cumplan las condiciones.
+Hace tres cosas que un backend de chatbot típico no hace:
+
+1. **Le dice al LLM qué pedir a continuación.** El `GoalStrategyEngine` recorre un DAG de checkpoints y devuelve una directiva como "ya tienes producto y ciudad; falta dirección y teléfono; no empujes el cierre todavía".
+2. **Valida cada dato extraído antes de aceptarlo.** Si el LLM dice "el usuario confirmó el pedido" pero todavía no tenemos teléfono, esa confirmación se ignora (y se registra un warning). El orden se respeta por código, no por rezar al prompt.
+3. **Auto-escala a humano cuando corresponde.** Cuando se completan todos los datos de compra (incluyendo comprobante de pago), la conversación pasa a `human_handoff` automáticamente.
 
 ---
 
-## La innovación: tres capas de control
+## Cómo funciona: el patrón de dos llamadas
 
-La mayoría de los sistemas confunden estas tres capas. Aquí están separadas y son independientes:
-
-### Capa 1: ¿Qué puede hacer el agente? — Máquina de estados
-
-Controla qué **acciones están permitidas** según la fase de la conversación.
-
-```
-Estado ACTIVE  → puede: preguntar, buscar productos, escalar
-Estado SELLING → puede: presentar producto, proponer orden, preguntar
-Estado ORDERING → puede: recopilar envío, confirmar orden, cancelar
-```
-
-Un agente en estado `active` **no puede** crear un pedido. No es una instrucción en el prompt — es que esa acción simplemente no está disponible. Esto se llama restricción arquitectónica.
-
-### Capa 2: ¿Qué debe hacer el agente ahora? — GoalStrategyEngine
-
-Controla qué **acción es óptima** dado el progreso de la conversación.
-
-El engine evalúa un DAG (grafo de dependencias) de checkpoints y responde: "Tienes intent e producto identificados, pero falta el nombre del cliente. Tu tarea esta ronda: preguntar el nombre."
-
-Esto es lo que recibe el LLM en su system prompt — no un listado de instrucciones genéricas, sino una directiva precisa basada en el estado real de la conversación.
-
-### Capa 3: ¿Es válida esta mutación de negocio? — Validación de acciones
-
-Controla qué **cambios en la base de datos son correctos**.
-
-Cuando el agente propone "crear pedido", el backend verifica:
-- ¿Existen los productos en el catálogo del cliente?
-- ¿El precio viene de la tabla `products`, no del agente?
-- ¿Hay ítems en el pedido?
-- ¿El usuario confirmó explícitamente?
-
-Si algo falla, el pedido no se crea — pero la respuesta de texto del agente **sí llega al usuario**. La conversación no se interrumpe.
-
-> **Resultado:** El sistema tiene un 100% de predictibilidad en las mutaciones de negocio y mantiene la naturalidad del lenguaje del LLM. Las investigaciones académicas (PPDPP, ICLR 2024; ChatSOP, ACL 2025) reportan mejoras de 27–91% en controllability con este patrón.
-
----
-
-## Arquitectura: el patrón de dos llamadas
-
-Cada mensaje de WhatsApp genera exactamente dos llamadas HTTP desde n8n hacia este backend, y una llamada al LLM. Sin herramientas, sin loops, sin llamadas extra.
+Cada mensaje entrante en WhatsApp genera **exactamente 2 llamadas HTTP** de n8n al backend y **1 llamada al LLM**. Sin tool-calling, sin loops.
 
 ```
 ┌─────────────────────────────────────────────────────────────────────┐
@@ -90,265 +55,221 @@ Cada mensaje de WhatsApp genera exactamente dos llamadas HTTP desde n8n hacia es
 │                                                                     │
 │  WhatsApp ──► n8n ──► LLAMADA 1: POST /api/v1/ingest/message       │
 │                           │                                         │
-│                           │  Backend hace (en 1 transacción):       │
-│                           │  1. Validar cliente (tenant)            │
-│                           │  2. Verificar idempotencia              │
-│                           │  3. Upsert del usuario                  │
-│                           │  4. Verificar si está bloqueado         │
-│                           │  5. Encontrar/crear conversación (24h)  │
-│                           │  6. Advisory lock (concurrencia)        │
-│                           │  7. Guardar mensaje entrante            │
-│                           │  8. Actualizar contadores               │
-│                           │  9. Calcular estrategia (DAG)           │
-│                           │  10. Persistir versión de estrategia    │
+│                           │  Backend (1 transacción):               │
+│                           │   1. Validar cliente (tenant)           │
+│                           │   2. Verificar idempotencia             │
+│                           │   3. Upsert client_user                 │
+│                           │   4. Bloqueo de usuario                 │
+│                           │   5. Conversación (ventana 24h, reset   │
+│                           │      extracted_context si idle 30+min)  │
+│                           │   6. Advisory lock (concurrencia)       │
+│                           │   7. Persistir mensaje entrante         │
+│                           │   8. Debounce 5s (evita responder       │
+│                           │      cuando hay mensajes encolados)     │
+│                           │   9. Calcular directiva (DAG)           │
+│                           │  10. Persistir strategy_version + meta  │
 │                           │                                         │
 │                           ▼                                         │
-│                    Respuesta con:                                   │
-│                    - strategy_directive (para el system prompt)     │
-│                    - available_actions (qué puede proponer)         │
-│                    - client_config (prompt base del cliente)        │
-│                    - strategy_version (número de versión)           │
-│                    - recent_messages (historial reciente)           │
+│                    Responde:                                        │
+│                    • strategy_directive (texto para el LLM)         │
+│                    • strategy_meta (goal, progress, checkpoint)     │
+│                    • strategy_version (número entero, clave)        │
+│                    • client_config (system_prompt, modelo, temp)    │
+│                    • user_context (display_name, flags has_*)       │
+│                    • product_catalog (con UUID + SKU + precio)      │
+│                    • business_context (bloque de reglas formateado) │
+│                    • conversation_summary (lo ya sabido)            │
+│                    • recent_messages (últimos 20)                   │
 │                           │                                         │
 │                           ▼                                         │
-│               n8n construye system prompt:                          │
-│               client_config.system_prompt_template                  │
-│               + strategy_directive                                  │
-│               + available_actions                                   │
-│                           │                                         │
-│                           ▼                                         │
-│               n8n llama al LLM (OpenAI)                            │
-│               LLM produce: response_text + proposed_action          │
+│               n8n arma el system prompt y llama al LLM             │
+│               LLM devuelve: response_text + extracted_data          │
 │                           │                                         │
 │                           ▼                                         │
 │              LLAMADA 2: POST /api/v1/agent/action                  │
 │                           │                                         │
-│                           │  Backend hace:                          │
-│                           │  1. Verificar strategy_version          │
-│                           │     (¿cambió la conversación?)          │
-│                           │  2. Validar acción vs máquina estados   │
-│                           │  3. Ejecutar handler de negocio         │
-│                           │  4. Validar transición de estado        │
-│                           │  5. Guardar mensaje saliente            │
-│                           │  6. Escribir audit log                  │
+│                           │  Backend:                               │
+│                           │   1. Verificar strategy_version         │
+│                           │      (si no coincide → 409)             │
+│                           │   2. Mergear extracted_data en          │
+│                           │      conversation.extracted_context,    │
+│                           │      aplicando DAG gates                │
+│                           │   3. Si todos los checkpoints listos    │
+│                           │      → auto-escalar a human_handoff     │
+│                           │   4. Aplicar proposed_transition (raro) │
+│                           │   5. Persistir mensaje saliente         │
+│                           │   6. Audit log                          │
 │                           │                                         │
 │                           ▼                                         │
-│                    Respuesta con:                                   │
-│                    - approved: true/false                           │
-│                    - final_response_text                            │
-│                    - new_state                                      │
-│                    - side_effects                                   │
+│                    Responde:                                        │
+│                    • approved, final_response_text                  │
+│                    • new_state                                      │
+│                    • side_effects (context_updated, escalated,      │
+│                      warning:premature_summary, …)                  │
 │                           │                                         │
 │                           ▼                                         │
 │               n8n envía final_response_text → WhatsApp             │
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
-**Propiedad clave:** Si la llamada 2 rechaza la acción de negocio, el texto de respuesta igual llega al usuario. La conversación nunca se interrumpe por un fallo del backend.
+**Propiedad clave:** si el backend rechaza un dato (p. ej. `user_confirmation` sin teléfono), el texto que el LLM generó **igual se envía al usuario**. La conversación no se interrumpe — solo no se persiste el dato prematuro.
 
 ---
 
-## Flujo de una conversación completa
+## El GoalStrategyEngine
 
-Este es un ejemplo real de cómo progresa una venta de principio a fin:
+Función pura: `(goal, extracted_context, business_rules) → StrategyDirective`. Sin DB, sin LLM, sin red. Corre en microsegundos.
+
+### DAG actual del goal `close_sale`
 
 ```
-Cliente: "Hola, quiero pedir café"
-                    │
-                    ▼
-           Backend → GoalStrategy
-           goal: close_sale
-           checkpoint actual: intent_identified
-           directiva: "Pregunta qué está buscando el cliente"
-           available_actions: [classify_intent, ask_question, ...]
-                    │
-                    ▼
-           LLM: "¡Hola Carlos! ¿Qué tipo de café te interesa?"
-           proposed_action: classify_intent
-           proposed_transition: qualifying
-                    │
-                    ▼
-           Backend valida:
-           ✓ classify_intent permitida en estado active
-           ✓ transición active→qualifying válida
-           Estado: active → qualifying
-
-─────────────────────────────────────────────
-
-Cliente: "El café molido premium"
-                    │
-                    ▼
-           Backend → GoalStrategy
-           checkpoint actual: product_matched ✓, lead_qualified
-           directiva: "Pregunta el nombre completo del cliente"
-           available_actions: [ask_question, create_lead, ...]
-                    │
-                    ▼
-           LLM: "¡Excelente elección! ¿Me puedes dar tu nombre completo?"
-           proposed_action: update_lead_data
-           extracted_data: {intent: "café molido", product_id: "uuid-cafe-molido"}
-                    │
-                    ▼
-           Backend:
-           ✓ update_lead_data permitida en estado qualifying
-           ✓ qualification_data actualizada en base de datos
-
-─────────────────────────────────────────────
-
-Cliente: "Me llamo Carlos Pérez"
-                    │
-                    ▼
-           Backend → GoalStrategy
-           checkpoint actual: shipping_info_collected
-           directiva: "Pide la dirección de envío"
-                    │
-                    ▼
-           LLM: "Perfecto Carlos, ¿a qué dirección enviamos?"
-           proposed_action: update_lead_data
-           extracted_data: {full_name: "Carlos Pérez"}
-
-─────────────────────────────────────────────
-
-Cliente: "Calle 10 #5-20, Manizales"
-                    │
-                    ▼
-           Backend → GoalStrategy
-           checkpoints completos: intent, product, lead_qualified, shipping
-           checkpoint actual: order_created
-           directiva: "Presenta resumen del pedido y pide confirmación"
-                    │
-                    ▼
-           LLM: "Resumen: Café Molido Premium $25.000 + envío..."
-           proposed_action: propose_order
-           extracted_data: {items: [{product_id: "...", quantity: 1}]}
-                    │
-                    ▼
-           Backend:
-           ✓ propose_order permitida en estado selling
-           ✓ precio tomado de products.price (NO del agente)
-           ✓ ORDER creada con status=draft
-           side_effects: ["order_created:uuid"]
-
-─────────────────────────────────────────────
-
-Cliente: "Sí, confirmo"
-                    │
-                    ▼
-           Backend → GoalStrategy
-           checkpoint actual: user_confirmed
-                    │
-                    ▼
-           LLM: "¡Pedido confirmado! Te llegará en 2-3 días."
-           proposed_action: confirm_order
-           extracted_data: {user_confirmation: true, shipping_name: "Carlos Pérez", ...}
-                    │
-                    ▼
-           Backend valida:
-           ✓ confirm_order válida en estado ordering
-           ✓ order tiene line_items
-           ✓ tiene shipping_address
-           ✓ user_confirmation = true
-           ORDER: draft → confirmed
-           side_effects: ["order_confirmed:uuid"]
+product_matched ─────────┐
+   (product_id)          │
+        │                ▼
+        │          lead_qualified
+        │          (full_name, phone)
+        │                │
+        │                ▼
+        │         shipping_info_collected
+        │         (shipping_address, shipping_city)
+        │                │
+        └────────────────┤
+                         ▼
+                   user_confirmed
+                   (user_confirmation)
+                         │
+                         ▼
+                  payment_confirmed
+                  (payment_confirmation)
 ```
+
+> **Nota histórica:** los checkpoints `intent_identified` y `order_created` fueron removidos. `intent` nunca se capturaba de forma confiable (bloqueaba el auto-escalate), y `order_created` requería materializar órdenes en DB — algo que hoy se maneja manualmente por WhatsApp.
+
+### Ejemplo de directiva generada
+
+```
+SALES PROGRESS: [████░░░░░░] 40%
+NEXT INFO NEEDED: shipping_address, shipping_city
+HINT (low priority, only when the conversation flows there naturally):
+  try to learn the full delivery address (neighborhood, street, number, apartment).
+IMPORTANT: Your priority is to have a warm, natural conversation.
+Answer what the customer asks.
+Do NOT mention or push toward the next step unless the customer brings it up.
+Never end a message with 'puedo ayudarte con el pedido' or similar sales push.
+```
+
+### Business rules que modifican el DAG
+
+Configurables por cliente en `clients.business_rules` (JSONB):
+
+| Regla | Efecto |
+|---|---|
+| `skip_lead_qualification: true` | Elimina el checkpoint `lead_qualified`. |
+| `require_id_number: true` | Agrega `identification_number` a los campos requeridos. |
+| `require_email: true` | Agrega `email` a los campos requeridos. |
 
 ---
 
-## Los endpoints en detalle
+## DAG gates en `agent_action`
 
-### Autenticación
+Cuando el LLM devuelve `extracted_data`, el backend lo mergea en `conversation.extracted_context` — **pero solo si el orden del DAG lo permite**. Los gates que existen hoy:
 
-Todos los endpoints (excepto `/health`) requieren:
+| Campo que el LLM intenta guardar | Requisito previo | Qué pasa si falta |
+|---|---|---|
+| `user_confirmation` | `full_name`, `phone`, `shipping_address`, `shipping_city` | Se descarta y se registra `warning:premature_summary_missing_<campos>` en `side_effects`. |
+| `payment_confirmation` | `user_confirmation`, `phone`, `shipping_address` | Se descarta silenciosamente (warning en logs). |
+
+Los demás campos (`product_id`, `full_name`, `phone`, `shipping_*`) se aceptan siempre que vengan con valor truthy — el DAG los ordena naturalmente por `blocked_by`.
+
+**Auto-escalate:** cuando todos los checkpoints del DAG están completos, la conversación pasa de `active` → `human_handoff` y aparece `escalated:purchase_data_complete` en `side_effects`. n8n puede usar ese flag para notificar al operador humano.
+
+---
+
+## Máquina de estados de conversación
+
+```
+              mensaje entrante
+                     │
+                     ▼
+                ┌─────────┐
+         ┌──────┤ active  ├──────┐
+         │      └─────────┘      │
+         │     auto-escalate     │
+         │  (all checkpoints OK) │
+         ▼                       ▼
+  ┌────────────────┐        ┌─────────┐
+  │ human_handoff  │        │ closed  │
+  └────────────────┘        └─────────┘
+         │                       ▲
+         └───────────────────────┘
+              operador cierra
+```
+
+Estados y transiciones permitidas:
+
+| Estado | Transiciones válidas |
+|---|---|
+| `active` | → `human_handoff`, `closed` |
+| `human_handoff` | → `active`, `closed` |
+| `closed` | (terminal) |
+
+> **Histórico:** la máquina original tenía 7 estados (`idle`, `qualifying`, `selling`, `ordering`, etc.). En la práctica ninguna conversación transicionó fuera de `active`/`human_handoff`, así que se colapsó a 3 estados en el refactor 2026-04-19.
+
+---
+
+## Endpoints
+
+Autenticación para todos los endpoints excepto `/health`:
 
 ```
 Authorization: Bearer <SALES_AI_SERVICE_TOKEN>
-X-Client-ID: <UUID del cliente/tenant>
+X-Client-ID: <UUID del tenant>
 ```
 
-El token se valida con `hmac.compare_digest` para prevenir timing attacks. El `X-Client-ID` identifica el tenant — todas las queries filtran por este ID.
-
----
+El token se valida con `hmac.compare_digest` (constant-time). `X-Client-ID` identifica el tenant — todas las queries filtran por este ID.
 
 ### GET /health
 
-Verificar que el backend está corriendo. No requiere autenticación.
-
-```bash
-curl https://ca-backend.thankfulglacier-96e7c984.eastus.azurecontainerapps.io/health
-```
-
-```json
-{"status": "ok"}
-```
-
----
+Sin auth. `{"status": "ok"}`.
 
 ### POST /api/v1/ingest/message
 
-**Llamada 1 del patrón de dos llamadas.** Procesa un mensaje entrante de WhatsApp.
+Procesa un mensaje entrante.
 
-#### Request
+**Request:**
 
-```bash
-curl -X POST https://ca-backend.thankfulglacier-96e7c984.eastus.azurecontainerapps.io/api/v1/ingest/message \
-  -H "Authorization: Bearer <TOKEN>" \
-  -H "X-Client-ID: 00000000-0000-0000-0000-000000000001" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "chakra_message_id": "msg-whatsapp-abc123",
-    "phone_number": "+573001234567",
-    "content": "Hola, quiero comprar café",
-    "display_name": "Carlos",
-    "message_type": "text"
-  }'
+```json
+{
+  "chakra_message_id": "wa-abc-123",
+  "phone_number": "+573001234567",
+  "content": "Hola, quiero café",
+  "display_name": "Carlos",
+  "message_type": "text"
+}
 ```
 
-| Campo | Tipo | Descripción |
-|---|---|---|
-| `chakra_message_id` | string | ID único del mensaje en Chakra. Garantiza idempotencia — el mismo ID nunca se procesa dos veces. |
-| `phone_number` | string | Número de WhatsApp del cliente. |
-| `content` | string | Texto del mensaje. |
-| `display_name` | string? | Nombre del cliente (opcional, se actualiza si ya existe). |
-| `message_type` | string | `"text"` por defecto. |
-
-#### Response
+**Response (simplificada):**
 
 ```json
 {
   "should_respond": true,
-  "conversation_id": "c420db40-1249-4fe7-8cdf-70805cb7759f",
+  "conversation_id": "c420db40-…",
   "conversation_state": "active",
-
-  "strategy_directive": "CURRENT GOAL: close_sale\nPROGRESS: [░░░░░░░░░░] 0%\nCURRENT STEP: Intent identified\nYOUR TASK THIS TURN: Ask what the customer is looking for today.\nINFORMATION STILL NEEDED:\n  • intent\nRULES:\n- Focus on collecting the missing information listed above\n- Do NOT skip ahead to later steps\n- Do NOT ask for multiple pieces of information at once\n- NEVER invent or assume information the customer hasn't provided",
-
+  "strategy_directive": "SALES PROGRESS: [░░░░░░░░░░] 0%\nNEXT INFO NEEDED: product_id\n…",
   "strategy_meta": {
     "goal": "close_sale",
     "progress_pct": 0,
-    "current_checkpoint": "intent_identified",
-    "next_action": "Ask what the customer is looking for today.",
-    "missing_fields": ["intent"]
+    "current_checkpoint": "product_matched",
+    "next_action": "Help the customer choose a product from the catalog.",
+    "missing_fields": ["product_id"]
   },
-
   "strategy_version": 1,
-
-  "available_actions": [
-    "classify_intent",
-    "ask_question",
-    "search_products",
-    "escalate"
-  ],
-
   "client_config": {
-    "system_prompt_template": "Eres un asistente de ventas para Café Demo...",
+    "system_prompt_template": "Eres Sebastian…",
     "ai_model": "gpt-4o-mini",
     "ai_temperature": 0.3,
-    "business_rules": {
-      "currency": "COP",
-      "default_goal": "close_sale",
-      "shipping_cities": ["Manizales", "Pereira", "Armenia"]
-    }
+    "business_rules": {…}
   },
-
   "user_context": {
     "display_name": "Carlos",
     "phone_number": "*********4567",
@@ -358,401 +279,157 @@ curl -X POST https://ca-backend.thankfulglacier-96e7c984.eastus.azurecontainerap
     "has_city": false,
     "is_blocked": false
   },
-
-  "recent_messages": [
-    {
-      "id": "...",
-      "direction": "inbound",
-      "content": "Hola, quiero comprar café",
-      "message_type": "text",
-      "created_at": "2026-04-04T20:23:18Z"
-    }
-  ]
+  "product_catalog": [{"id": "<uuid>", "name": "…", "sku": "…", "price": 40000, …}],
+  "business_context": "PRODUCT CATALOG:\n- Café Arenillo (id: <uuid>, sku: CAFE-001): $40.000 COP\n…",
+  "conversation_summary": "CUSTOMER CONTEXT: New customer, no data collected yet.",
+  "recent_messages": [ … ]
 }
 ```
 
-| Campo | Cómo usarlo |
-|---|---|
-| `should_respond` | Si es `false`, es un mensaje duplicado o el usuario está bloqueado. No llamar al LLM. |
-| `strategy_directive` | **Inyectar directamente en el system prompt del LLM.** Es el texto que le dice al agente qué perseguir. |
-| `available_actions` | Incluir en el system prompt como lista de acciones disponibles. |
-| `strategy_version` | **Guardar y enviar en la Llamada 2.** Si la conversación cambia entre llamadas, el backend detecta la inconsistencia. |
-| `client_config.system_prompt_template` | El prompt base del cliente. Concatenar con `strategy_directive` y `available_actions`. |
-| `recent_messages` | Historial para el contexto del LLM. |
-
-#### Cómo construir el system prompt para el LLM
-
-```
-{client_config.system_prompt_template}
-
----
-{strategy_directive}
-
----
-ACCIONES DISPONIBLES EN ESTE TURNO:
-{available_actions}
-Para proponer una acción, incluye en tu respuesta:
-ACTION: <nombre_accion>
-DATA: <json con datos extraídos>
-TRANSITION: <nuevo_estado_si_corresponde>
-```
-
-#### Casos especiales
-
-**Mensaje duplicado** (mismo `chakra_message_id`):
-```json
-{"should_respond": false, ...}
-```
-
-**Cliente inactivo:**
-```
-HTTP 404 — "Client not found or inactive"
-```
-
-**Usuario bloqueado:**
-```
-HTTP 403 — "User is blocked"
-```
-
----
+**Casos especiales:**
+- Duplicado (mismo `chakra_message_id`): `{"should_respond": false, …}`.
+- Cliente inactivo: `HTTP 404`.
+- Usuario bloqueado: `HTTP 403`.
+- Debounce: si llega otro mensaje en los 5 segundos siguientes, este turno no responde (`should_respond: false` con reason `debounce`).
 
 ### POST /api/v1/agent/action
 
-**Llamada 2 del patrón de dos llamadas.** Valida la respuesta del LLM y ejecuta acciones de negocio.
+Persiste el turno del agente y mergea datos extraídos.
 
-#### Request
+**Request:**
 
-```bash
-curl -X POST https://ca-backend.thankfulglacier-96e7c984.eastus.azurecontainerapps.io/api/v1/agent/action \
-  -H "Authorization: Bearer <TOKEN>" \
-  -H "X-Client-ID: 00000000-0000-0000-0000-000000000001" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "conversation_id": "c420db40-1249-4fe7-8cdf-70805cb7759f",
-    "strategy_version": 1,
-    "response_text": "¡Hola Carlos! ¿Qué tipo de café te interesa hoy?",
-    "proposed_action": "classify_intent",
-    "proposed_transition": "qualifying",
-    "extracted_data": {
-      "intent": "comprar café molido"
-    },
-    "ai_model": "gpt-4o-mini",
-    "prompt_tokens": 245,
-    "completion_tokens": 38,
-    "latency_ms": 820
-  }'
+```json
+{
+  "conversation_id": "c420db40-…",
+  "strategy_version": 1,
+  "response_text": "Hola, soy Sebastian de Café Arenillo. ¿En qué te puedo ayudar?",
+  "extracted_data": {
+    "product_id": "<uuid del catálogo, NUNCA el SKU>",
+    "full_name": "Juan Pérez",
+    "phone": "3001234567",
+    "shipping_city": "Manizales",
+    "shipping_address": "Calle 10 #5-20",
+    "user_confirmation": true,
+    "send_image_url": "https://…"
+  },
+  "proposed_transition": null,
+  "ai_model": "gpt-4o-mini",
+  "prompt_tokens": 245,
+  "completion_tokens": 38,
+  "latency_ms": 820
+}
 ```
 
-| Campo | Tipo | Descripción |
-|---|---|---|
-| `conversation_id` | UUID | De la respuesta de Llamada 1. |
-| `strategy_version` | int | **Obligatorio.** De la respuesta de Llamada 1. Detecta contextos desactualizados. |
-| `response_text` | string | El texto que generó el LLM. Llega al usuario independientemente del resultado. |
-| `proposed_action` | string? | Acción de negocio que propone el agente (ver lista abajo). |
-| `proposed_transition` | string? | Nuevo estado de conversación que propone el agente. |
-| `extracted_data` | dict? | Datos extraídos por el LLM de la conversación. |
-| `ai_model` | string? | Modelo usado (para auditoría). |
-| `prompt_tokens` | int? | Tokens del prompt (para control de costos). |
-| `completion_tokens` | int? | Tokens de la respuesta (para control de costos). |
-| `latency_ms` | int? | Latencia del LLM en ms (para monitoreo). |
+> `proposed_action` existe en el schema por compatibilidad pero ya no se valida ni ejecuta. El contrato real del turno es: `response_text` + `extracted_data`.
 
-#### Acciones de negocio disponibles
-
-| Acción | Estado requerido | Qué hace |
-|---|---|---|
-| `classify_intent` | active | Informacional. Sin efecto en DB. |
-| `ask_question` | cualquiera | Informacional. Sin efecto en DB. |
-| `search_products` | active, selling | Informacional. Sin efecto en DB. |
-| `create_lead` | qualifying | Crea un lead vinculado a la conversación. Requiere `intent` en `extracted_data`. |
-| `update_lead_data` | qualifying | Merge de datos de calificación en el lead existente. |
-| `propose_order` | selling | Crea un pedido DRAFT. Precios tomados del catálogo, nunca del agente. |
-| `confirm_order` | ordering | Confirma el pedido. Requiere `shipping_address` + `user_confirmation: true`. |
-| `cancel_order` | ordering | Cancela el pedido. Solo posible desde estado draft o confirmed. |
-| `escalate` | cualquiera | Pasa a `human_handoff`. |
-
-#### Response
+**Response:**
 
 ```json
 {
   "approved": true,
-  "final_response_text": "¡Hola Carlos! ¿Qué tipo de café te interesa hoy?",
-  "new_state": "qualifying",
-  "side_effects": [
-    "state_changed:active→qualifying"
-  ],
+  "final_response_text": "Hola, soy Sebastian de Café Arenillo. ¿En qué te puedo ayudar?",
+  "new_state": "active",
+  "side_effects": ["context_updated:['full_name', 'phone']"],
   "rejection_reason": null
 }
 ```
 
-| Campo | Descripción |
-|---|---|
-| `approved` | `true` si la acción de negocio se ejecutó. `false` si fue rechazada por reglas. |
-| `final_response_text` | El texto a enviar al usuario. **Siempre presente**, incluso si `approved = false`. |
-| `new_state` | Estado actual de la conversación después de este turno. |
-| `side_effects` | Lista de efectos: `lead_created:uuid`, `order_created:uuid`, `state_changed:X→Y`, etc. |
-| `rejection_reason` | Si `approved = false`, explica por qué. El usuario no necesita saberlo. |
+**Side effects observables:**
+- `context_updated:[…]` — campos mergeados a `extracted_context`.
+- `warning:premature_summary_missing_<campos>` — el LLM intentó confirmar algo sin datos suficientes.
+- `escalated:purchase_data_complete` — todos los checkpoints completos; conversación pasa a `human_handoff`.
+- `state_changed:active→human_handoff` — transición aplicada.
+- `transition_rejected:…` — transición inválida descartada.
 
-#### Casos especiales
-
-**Contexto desactualizado** (otro mensaje llegó entre Llamada 1 y Llamada 2):
-```
-HTTP 409 — {"error": "stale_context", "message": "strategy_version mismatch"}
-```
-Solución: volver a llamar a Llamada 1 con el mismo mensaje para obtener el contexto actualizado.
-
-**Acción rechazada pero respuesta enviada:**
-```json
-{
-  "approved": false,
-  "final_response_text": "¡Por supuesto, aquí está tu pedido!",
-  "new_state": "active",
-  "side_effects": [],
-  "rejection_reason": "Action 'propose_order' is not allowed in state 'active'"
-}
-```
-El texto del LLM llega al usuario. El pedido NO se creó. La conversación continúa.
+**Casos especiales:**
+- `strategy_version` desfasada (otro mensaje llegó entre Llamada 1 y 2): `HTTP 409 {"error": "stale_context"}`. Solución: n8n re-llama a `ingest` con el mismo mensaje.
+- Conversación no encontrada: `HTTP 404`.
 
 ---
 
-## Ejemplo concreto: vender un café
+## Ejemplo concreto end-to-end
 
-A continuación el ciclo completo de una venta usando `curl`. Sirve para entender exactamente qué hace el backend en cada paso.
+Una venta completa, tal como se refleja hoy en la DB:
 
-### Paso 1 — Cliente dice "Hola"
+```
+Cliente: "Hola, me interesa café"
+  ─► ingest: progress 0%, checkpoint=product_matched
+  ─► LLM devuelve: "Hola, soy Sebastian de Café Arenillo. ¿En qué te puedo ayudar?"
+       extracted_data: {}
+  ─► agent/action: context_updated:[] (nada que guardar)
 
-```bash
-# LLAMADA 1
-curl -X POST .../api/v1/ingest/message \
-  -H "Authorization: Bearer <TOKEN>" \
-  -H "X-Client-ID: 00000000-0000-0000-0000-000000000001" \
-  -d '{
-    "chakra_message_id": "wa-001",
-    "phone_number": "+573001234567",
-    "content": "Hola, quiero café"
-  }'
+Cliente: "Quiero 3 bolsas"
+  ─► ingest: progress 0%, checkpoint=product_matched
+  ─► LLM: "¡Listo! Para continuar con el pedido, ¿me das tu nombre completo?"
+       extracted_data: {"product_id": "<uuid>"}
+  ─► agent/action: context_updated:['product_id'], progress ahora 20%
 
-# Backend responde:
-# strategy_directive: "Tu tarea: pregunta qué está buscando"
-# available_actions: [classify_intent, ask_question, search_products, escalate]
-# strategy_version: 1
+Cliente: "Juan Pérez, 3001234567"
+  ─► ingest: progress 20%, checkpoint=lead_qualified
+  ─► LLM: "Gracias Juan. ¿A qué ciudad y dirección enviamos?"
+       extracted_data: {"full_name": "Juan Pérez", "phone": "3001234567"}
+  ─► agent/action: context_updated:['full_name','phone'], progress 40%
 
-# LLM genera: "¡Hola! ¿Qué tipo de café te interesa?"
-# proposed_action: classify_intent
-# extracted_data: {}
+Cliente: "Manizales, Calle 10 #5-20"
+  ─► LLM: resumen + pide confirmación
+       extracted_data: {"shipping_city":"Manizales", "shipping_address":"Calle 10 #5-20"}
+  ─► agent/action: context_updated:['shipping_city','shipping_address'], progress 60%
 
-# LLAMADA 2
-curl -X POST .../api/v1/agent/action \
-  -d '{
-    "conversation_id": "<uuid>",
-    "strategy_version": 1,
-    "response_text": "¡Hola! ¿Qué tipo de café te interesa?",
-    "proposed_action": "classify_intent",
-    "proposed_transition": "qualifying",
-    "extracted_data": {}
-  }'
+Cliente: "Sí, confirmo"
+  ─► LLM: comparte medios de pago
+       extracted_data: {"user_confirmation": true}
+  ─► agent/action:
+       [DAG gate verifica: full_name ✓, phone ✓, shipping_address ✓, shipping_city ✓]
+       context_updated:['user_confirmation'], progress 80%
 
-# Backend responde:
-# approved: true, new_state: "qualifying"
-# side_effects: ["state_changed:active→qualifying"]
+Cliente: (envía foto del comprobante)
+  ─► LLM: "Recibido, gracias. Alguien del equipo te escribe pronto."
+       extracted_data: {"payment_confirmation": true}
+  ─► agent/action:
+       [DAG gate verifica: user_confirmation ✓, phone ✓, shipping_address ✓]
+       context_updated:['payment_confirmation'], progress 100%
+       auto-escalate → state: active → human_handoff
+       side_effects: ["escalated:purchase_data_complete",
+                      "state_changed:active→human_handoff"]
 ```
 
-### Paso 2 — Cliente dice el producto
-
-```bash
-# LLAMADA 1 — nuevo mensaje
-curl -X POST .../api/v1/ingest/message \
-  -d '{
-    "chakra_message_id": "wa-002",
-    "phone_number": "+573001234567",
-    "content": "El café molido premium"
-  }'
-
-# Backend ahora sabe: estamos en qualifying, falta el nombre
-# strategy_directive: "Tu tarea: pregunta el nombre completo"
-# strategy_version: 2
-
-# LLM genera: "¡Excelente! ¿Me das tu nombre completo?"
-# proposed_action: update_lead_data
-# extracted_data: {intent: "café molido", product_id: "91916748-..."}
-
-# LLAMADA 2
-curl -X POST .../api/v1/agent/action \
-  -d '{
-    "strategy_version": 2,
-    "response_text": "¡Excelente! ¿Me das tu nombre completo?",
-    "proposed_action": "update_lead_data",
-    "extracted_data": {"intent": "café molido", "product_id": "91916748-7827-45a5-b9fb-f46d50c19be7"}
-  }'
-```
-
-### Paso 3 — Cliente da nombre y dirección
-
-```bash
-# (mensajes wa-003, wa-004 similares — backend acumula datos en extracted_context)
-# Cuando tiene: intent, product_id, full_name, shipping_address, shipping_city
-# strategy_directive: "Tu tarea: presenta el resumen del pedido"
-# available_actions ahora incluye: propose_order (estamos en selling)
-```
-
-### Paso 4 — Crear el pedido
-
-```bash
-# LLAMADA 2 con acción de negocio real
-curl -X POST .../api/v1/agent/action \
-  -d '{
-    "strategy_version": 5,
-    "response_text": "Tu pedido: Café Molido Premium × 1 = $25.000 COP. ¿Confirmamos?",
-    "proposed_action": "propose_order",
-    "proposed_transition": "ordering",
-    "extracted_data": {
-      "items": [
-        {"product_id": "91916748-7827-45a5-b9fb-f46d50c19be7", "quantity": 1}
-      ]
-    }
-  }'
-
-# Backend:
-# 1. Verifica que propose_order está permitida en estado "selling" ✓
-# 2. Busca el producto en la tabla products para Café Demo ✓
-# 3. Toma el precio de la DB ($25.000) — ignora cualquier precio del agente
-# 4. Crea ORDER con status=draft + ORDER_LINE_ITEMS
-# 5. Retorna:
-# {
-#   "approved": true,
-#   "new_state": "ordering",
-#   "side_effects": ["order_created:uuid-del-pedido", "state_changed:selling→ordering"]
-# }
-```
-
-### Paso 5 — Cliente confirma
-
-```bash
-# LLAMADA 2 final
-curl -X POST .../api/v1/agent/action \
-  -d '{
-    "strategy_version": 6,
-    "response_text": "¡Pedido confirmado! Llega en 2-3 días hábiles.",
-    "proposed_action": "confirm_order",
-    "extracted_data": {
-      "user_confirmation": true,
-      "shipping_name": "Carlos Pérez",
-      "shipping_address": "Calle 10 #5-20",
-      "shipping_city": "Manizales"
-    }
-  }'
-
-# Backend verifica:
-# ✓ confirm_order permitida en estado "ordering"
-# ✓ order tiene line_items
-# ✓ tiene shipping_address
-# ✓ user_confirmation = true
-# ORDER: draft → confirmed
-# {
-#   "approved": true,
-#   "new_state": "ordering",
-#   "side_effects": ["order_confirmed:uuid-del-pedido"]
-# }
-```
+En cualquier punto, si el LLM intenta guardar `user_confirmation` sin los 4 datos previos, el gate lo rechaza y aparece `warning:premature_summary_missing_phone+shipping_city` en `side_effects`. El texto al usuario igual se envía — solo no se marca como confirmado.
 
 ---
 
-## El GoalStrategyEngine explicado
+## Limitaciones conocidas
 
-El engine es una función pura: `(goal, datos_recolectados, reglas_negocio) → directiva`. Sin base de datos, sin LLM, sin red. Corre en microsegundos.
+Estas son las fricciones reales del sistema tal como está hoy (2026-04-20). No están "rotas", pero conviene conocerlas para planear.
 
-### El DAG del goal `close_sale`
+### Flujo y conversación
 
-```
-intent_identified ──────────────────────────┐
-        │                                    │
-        ▼                                    ▼
-product_matched                      lead_qualified
-        │                                    │
-        │                                    ▼
-        │                         shipping_info_collected
-        │                                    │
-        └────────────────────────────────────┘
-                                             │
-                                             ▼
-                                      order_created
-                                             │
-                                             ▼
-                                      user_confirmed
-```
+- **Debounce frágil ante ráfagas rápidas.** El backend espera 5 s tras commitear el primer mensaje para ver si llegó otro. Si el cliente manda "Hola" + "Buena noche" con 10 s de diferencia, el debounce no los agrupa (el primero ya pasó los 5 s). Resultado: dos outbounds casi idénticos. **Fix propuesto** (pendiente): cambiar a debounce "rearmable" que espere N segundos de silencio desde el ÚLTIMO mensaje, no desde el primero.
+- **Reset de `extracted_context` por inactividad.** Si la conversación estuvo idle 30+ minutos, el backend limpia `extracted_context` al siguiente mensaje. Esto evita arrastrar datos viejos pero también borra contexto legítimo si el cliente tarda en responder.
+- **El LLM sigue siendo la fuente de verdad de la extracción.** Los DAG gates protegen el ORDEN pero no la PRECISIÓN. Si el LLM decide que `full_name="Sebastian"` (solo primer nombre), el backend lo acepta. La mitigación es vía prompt (regla "pide el apellido si responden con una palabra"), no por código. Lo mismo con ciudad inferida del nombre, cantidad deducida del contexto, etc.
+- **Foto del producto depende del LLM.** El rail `send_image_url` funciona por convención: el LLM debe incluirlo en `extracted_data` la primera vez y nunca más. No hay memoria backend que impida que lo envíe dos veces — solo la regla en el system prompt (reforzada 2026-04-20).
 
-Cada checkpoint tiene `required_fields` y `blocked_by`. El engine evalúa cuáles están completos, cuáles están bloqueados por dependencias, y cuál es el primero accionable.
+### Modelo de datos
 
-### Ejemplo de directiva generada
+- **Leads y órdenes no se materializan en DB.** Las tablas `leads`, `orders`, `order_line_items` existen pero llevan vacías desde el inicio. Los "datos del lead" viven en `conversations.extracted_context` como JSONB. Para remarketing o reportes hay que consultar ese JSONB. Si en el futuro se necesita materialización estructurada, hay que decidir: vista materializada + CRON, o sincronización on-write en `agent_action`.
+- **Pago manual.** La confirmación de pago es un flag booleano en `extracted_context` activado cuando el cliente dice "ya pagué" + envía comprobante. No hay verificación contra gateway, ni número de referencia, ni monto — un humano debe validar el comprobante en WhatsApp.
+- **`agent_turn_count` y `proposed_action` en schema pero no se leen.** Columnas heredadas del diseño original con handlers de acciones. Se mantienen para no hacer migración downgrade; el código nuevo las ignora.
 
-```
-CURRENT GOAL: close_sale
-PROGRESS: [████░░░░░░] 33%
-CURRENT STEP: Lead qualified
-YOUR TASK THIS TURN: Ask for the customer's full name naturally.
-INFORMATION STILL NEEDED:
-  • full_name
-  • shipping_address
-  • shipping_city
-COMPLETED:
-  ✓ intent_identified
-  ✓ product_matched
-RULES:
-- Focus on collecting the missing information listed above
-- Do NOT skip ahead to later steps
-- Do NOT ask for multiple pieces of information at once
-- NEVER invent or assume information the customer hasn't provided
-```
+### Integración n8n
 
-### Reglas de negocio que modifican el DAG
+- **Fallo silencioso del subworkflow.** Si el master workflow de n8n se ejecuta pero el subworkflow `cafe_arenillo_v2` no dispara (ID cambiado, trigger modificado, timeout), el backend no recibe el ingest y la conversación queda sin respuesta. **No hay telemetría desde el backend sobre esto** — solo se detecta mirando `/executions` en n8n. Ver incidente 2026-04-19.
+- **Timeout acoplado al debounce.** El backend introduce 5 s de latencia por el debounce. Si el HTTP timeout de n8n al backend es < 8-10 s, toda ingesta falla. Ajustar en n8n si se modifica el debounce.
 
-En la tabla `clients.business_rules` (JSONB) se configuran por cliente:
+### Operaciones
 
-| Regla | Efecto |
-|---|---|
-| `"skip_lead_qualification": true` | Elimina el checkpoint `lead_qualified`. Útil para ventas rápidas. |
-| `"require_id_number": true` | Agrega `identification_number` como campo requerido en lead. |
-| `"require_email": true` | Agrega `email` como campo requerido. |
+- **Sin dashboard.** La única forma de ver qué pasó en una conversación es `SELECT * FROM messages / conversations / audit_log`. No hay métricas agregadas, ni alertas, ni una vista de operador humano para `human_handoff`.
+- **Auth service-to-service con un solo token.** Todos los callers usan el mismo `SALES_AI_SERVICE_TOKEN`. No hay rotación automática ni scopes distintos por caller.
+- **Tests sin cobertura de integración.** Los 37 tests actuales son pure Python (goal_strategy, prompt_context, health/auth). No hay test end-to-end que corra contra Postgres real, así que regresiones de `ingest` o `agent_action` se detectan solo en staging/prod.
+- **Multi-tenant defendido por aplicación, no por DB.** Cada tabla tiene `client_id` FK nullable-false, pero no hay RLS (Row-Level Security) de Postgres. Un bug que olvide filtrar por `client_id` en una query podría leer datos cross-tenant. Revisar al tercer cliente.
 
----
+### Costos y rendimiento
 
-## La máquina de estados
-
-```
-                    ┌─────────┐
-                    │  IDLE   │
-                    └────┬────┘
-                         │ mensaje entrante
-                         ▼
-                    ┌─────────┐
-              ┌────►│ ACTIVE  │◄────────────────────┐
-              │     └────┬────┘                     │
-              │          │                          │
-         ┌────┘     ┌────┼────┐                     │
-         │          ▼    ▼    ▼                     │
-         │    ┌──────┐ ┌──────┐ ┌──────────────┐   │
-         │    │QUALIF│ │SELL. │ │HUMAN_HANDOFF │   │
-         │    └──┬───┘ └──┬───┘ └──────────────┘   │
-         │       │        │                         │
-         │       ▼        ▼                         │
-         │    ┌──────────────┐                      │
-         └────│   ORDERING   │──────────────────────┘
-              └──────┬───────┘
-                     │ confirm/cancel
-                     ▼
-                ┌─────────┐
-                │ CLOSED  │
-                └─────────┘
-```
-
-| Estado | Acciones disponibles |
-|---|---|
-| `idle` | greet, classify_intent |
-| `active` | classify_intent, ask_question, search_products, escalate |
-| `qualifying` | ask_question, create_lead, update_lead_data, escalate |
-| `selling` | search_products, present_product, propose_order, ask_question, escalate |
-| `ordering` | collect_shipping_info, confirm_order, modify_order, cancel_order, escalate |
-| `human_handoff` | notify_human |
-| `closed` | (ninguna) |
+- **1 LLM call por mensaje entrante.** Predecible pero no amortizable — si el cliente manda 10 mensajes seguidos, son 10 llamadas (aunque algunas se descarten por debounce tras el commit). Prompt con `business_context` + `recent_messages` + `strategy_directive` pesa ~1500-2500 tokens de entrada por turno.
+- **Advisory lock + transacción por mensaje.** Aguanta bien hasta cientos de conversaciones concurrentes en Postgres Flexible, pero no está testeado con ráfagas masivas.
 
 ---
 
@@ -760,31 +437,31 @@ En la tabla `clients.business_rules` (JSONB) se configuran por cliente:
 
 ### ¿Por qué async everywhere?
 
-WhatsApp puede enviar mensajes en ráfagas rápidas. Un mensaje nuevo puede llegar mientras se procesa el anterior. La combinación de async SQLAlchemy + asyncpg permite atender múltiples requests concurrentes sin bloquear el event loop. El advisory lock de PostgreSQL (`pg_advisory_xact_lock`) serializa los mensajes de la misma conversación sin necesidad de colas.
+WhatsApp manda ráfagas. Async SQLAlchemy + asyncpg permite atender requests concurrentes sin bloquear el event loop. El `pg_advisory_xact_lock` serializa los mensajes de la misma conversación sin necesidad de Redis o colas.
 
-### ¿Por qué PostgreSQL advisory locks en vez de Redis?
+### ¿Por qué advisory locks en vez de Redis?
 
-El advisory lock es transaccional — se libera automáticamente cuando la transacción hace commit o rollback. No hay que preocuparse por locks huérfanos si la aplicación falla. Y no agrega infraestructura extra (ya tenemos Postgres).
+El advisory lock es transaccional — se libera automáticamente con commit/rollback. No hay locks huérfanos si la app falla, y no agrega infra extra (ya tenemos Postgres).
 
-### ¿Por qué enums como VARCHAR + CHECK en vez de tipos nativos?
+### ¿Por qué ENUMs como VARCHAR + CHECK?
 
-PostgreSQL tiene un tipo `ENUM` nativo, pero para agregar un valor nuevo hay que correr `ALTER TYPE` que puede bloquear la tabla. Con `VARCHAR + CHECK CONSTRAINT`, agregar un estado es solo `ALTER TABLE ... DROP CONSTRAINT ... ADD CONSTRAINT ...` — no bloquea, no requiere downtime.
+Agregar un valor a un `ENUM` nativo requiere `ALTER TYPE`, que bloquea la tabla. Con `VARCHAR + CHECK CONSTRAINT`, modificar el set de valores es `DROP CONSTRAINT` + `ADD CONSTRAINT`, sin downtime.
 
-### ¿Por qué el agente no tiene herramientas (tools)?
+### ¿Por qué el agente no tiene tools?
 
-El patrón de tool-calling de LLMs crea loops impredecibles: el agente llama herramienta A, interpreta el resultado, llama herramienta B, etc. Cada llamada agrega latencia y costo. Nuestro patrón es lineal y determinista: exactamente 1 LLM call por mensaje, exactamente 2 HTTP calls al backend. El costo es constante y predecible.
+El tool-calling genera loops impredecibles: el LLM llama A, interpreta, llama B, etc. Cada iteración agrega latencia y costo. Este patrón es lineal: 1 LLM call por mensaje, 2 HTTP calls al backend. El costo es constante.
 
 ### ¿Por qué `strategy_version`?
 
-Entre la Llamada 1 (ingest) y la Llamada 2 (agent/action), puede ocurrir algo inesperado: el cliente envía otro mensaje, n8n hace un retry, hay un timeout. La `strategy_version` es un número entero que incrementa en cada ingest. Si entre las dos llamadas llegó otro mensaje y la versión cambió, el backend detecta la inconsistencia (HTTP 409) y n8n puede volver a llamar a ingest para obtener el contexto actualizado.
+Entre Llamada 1 y Llamada 2 puede llegar otro mensaje, o n8n puede hacer retry. `strategy_version` incrementa en cada ingest. Si la Llamada 2 trae una versión vieja, el backend responde 409 y n8n vuelve a llamar a ingest. Evita guardar datos sobre un contexto obsoleto.
 
-### ¿Por qué los precios vienen del backend y no del agente?
+### ¿Por qué el precio viene del catálogo, no del agente?
 
-El LLM puede alucinar precios. Si el agente propone "crear pedido con precio $5.000" para un producto que vale $25.000, el backend ignora el precio del agente y busca el producto en la tabla `products`. La prevención no está en el prompt — está en el código.
+El LLM puede alucinar precios. El sistema lee `products.price` cuando arma el `business_context`. Incluso si el LLM repite un precio en `response_text`, no hay mutación backend basada en ese precio — hoy no se materializan órdenes, y cuando se hagan, el precio vendrá del catálogo.
 
-### Multi-tenant con `client_id`
+### Multi-tenant por `client_id`
 
-Cada tabla tiene `client_id` como FK no nulable. Cada query filtra por `client_id`. Esto garantiza que los datos de un cliente nunca se mezclen con los de otro, incluso en el mismo pool de conexiones.
+Toda tabla tenant-facing tiene `client_id` FK no nulable. Toda query filtra por `client_id`. No hay RLS de Postgres — la separación es por convención en la capa de servicio.
 
 ---
 
@@ -800,39 +477,49 @@ agent-backend/
 │       ├── main.py               # App factory, auth middleware, routers
 │       │
 │       ├── core/
-│       │   └── database.py       # Async SQLAlchemy, resolución de credenciales
+│       │   └── database.py       # Async SQLAlchemy + resolución de credenciales
 │       │
 │       ├── models/
-│       │   └── core.py           # ORM: 9 tablas mapeadas al schema desplegado
+│       │   └── core.py           # ORM: 6 tablas activas (Client, ClientUser,
+│       │                         #   Product, Conversation, Message, AuditLog)
+│       │                         # Tablas leads/orders/order_line_items existen
+│       │                         # en Postgres pero sin mapeo ORM.
 │       │
 │       ├── api/v1/
 │       │   ├── ingest.py         # POST /api/v1/ingest/message
 │       │   └── agent.py          # POST /api/v1/agent/action
 │       │
 │       └── services/
-│           ├── state_machine.py  # 7 estados, validadores, excepciones tipadas
-│           ├── goal_strategy.py  # GoalStrategyEngine: DAG navigator
-│           ├── ingest.py         # Servicio de ingesta (10 pasos, 1 transacción)
-│           └── agent_action.py   # Validación y ejecución de acciones
+│           ├── state_machine.py  # 3 estados + validate_transition
+│           ├── goal_strategy.py  # GoalStrategyEngine (DAG navigator)
+│           ├── prompt_context.py # format_business_context + conversation_summary
+│           ├── ingest.py         # Servicio de ingesta (10 pasos + debounce)
+│           └── agent_action.py   # Merge de extracted_data + DAG gates + auto-escalate
 │
 ├── migrations/versions/
-│   ├── 001_initial_schema.sql    # Schema completo (ya desplegado)
-│   └── 002_peer_review_hardening.sql # Columnas de strategy + triggers
+│   ├── 001_initial_schema.sql
+│   ├── 002_peer_review_hardening.sql
+│   ├── 003_enrich_cafe_demo.sql
+│   ├── 004_improve_cafe_demo_prompt.sql
+│   └── 005_shipping_zones_product_images.sql
 │
 └── tests/
-    ├── test_health.py            # Tests de auth y health (5 tests)
+    ├── test_health.py                       # 5 tests de auth/health
     └── services/
-        └── test_goal_strategy.py # Tests del engine (18 tests, pure Python)
+        ├── test_goal_strategy.py            # 19 tests del engine
+        └── test_prompt_context.py           # 13 tests de formatters
 ```
+
+Total: **37 tests**, todos pure Python — sin DB, sin red. Corren en ~0.02 s.
 
 ---
 
-## Cómo correr el proyecto localmente
+## Correr localmente
 
 ### Prerrequisitos
 
 - Python 3.12
-- PostgreSQL 16 (o conexión a Azure)
+- Postgres 16 (local o acceso a Azure)
 
 ### Instalación
 
@@ -852,7 +539,7 @@ SALES_AI_SERVICE_TOKEN=mi-token-local-de-prueba
 ENV=dev
 ```
 
-O con Azure Key Vault:
+O resolviendo desde Azure Key Vault:
 
 ```dotenv
 KEY_VAULT_URL=https://kv-r8fm.vault.azure.net/
@@ -864,28 +551,23 @@ ENV=dev
 ### Correr tests
 
 ```bash
-# Desde agent-backend/
 pytest tests/ -v
 ```
 
-Todos los tests de servicios son pure Python — no necesitan base de datos ni red.
-
-### Correr la aplicación
+### Arrancar la app
 
 ```bash
 cd sales_agent_api
 uvicorn app.main:app --reload --port 8000
 ```
 
-Documentación interactiva en: http://localhost:8000/api/docs
+Docs interactivas: http://localhost:8000/api/docs (solo si `ENV != production`).
 
 ### Docker
 
 ```bash
-# Build
 docker build -t sales-agent-api -f sales_agent_api/Dockerfile sales_agent_api
 
-# Run
 docker run -p 8000:8000 \
   -e DATABASE_URL="postgresql+asyncpg://user:pass@host:5432/sales_ai" \
   -e SALES_AI_SERVICE_TOKEN="mi-token" \
@@ -893,22 +575,16 @@ docker run -p 8000:8000 \
   sales-agent-api
 ```
 
-### CI/CD
-
-Cada push a `main` ejecuta automáticamente:
-1. Tests (23 tests, ~1 segundo)
-2. Build y push de imagen Docker a Docker Hub
-3. Actualización del Container App en Azure (`ca-backend`, `rg-backend`)
-
 ---
 
-## Entorno de producción
+## Producción
 
 | Componente | Detalles |
 |---|---|
 | **Backend URL** | `https://ca-backend.thankfulglacier-96e7c984.eastus.azurecontainerapps.io` |
-| **Base de datos** | `psql-r8fm.postgres.database.azure.com` / `sales_ai` |
+| **Postgres** | `psql-r8fm.postgres.database.azure.com` / DB `sales_ai` |
 | **Key Vault** | `kv-r8fm` (DBUSERNAME, DBPASSWORD, DBHOST, DBNAME, sales-ai-service-token) |
-| **Managed Identity** | `uai-r8fm` — accede a Key Vault y ACR sin contraseñas en el código |
-| **CI/CD** | GitHub Actions → Docker Hub → Container App |
-| **Cliente demo** | Café Demo — ID `00000000-0000-0000-0000-000000000001` |
+| **Managed Identity** | `uai-r8fm` — accede a Key Vault y ACR sin contraseñas en código |
+| **CI/CD** | Push a `main` → GitHub Actions → tests → build Docker → push ACR → rollout Container App |
+| **Cliente demo** | Café Arenillo — ID `00000000-0000-0000-0000-000000000001` |
+| **n8n** | `ca-r8fm-n8n.thankfulglacier-96e7c984.eastus.azurecontainerapps.io` (orquesta Chakra ↔ backend ↔ OpenAI) |


### PR DESCRIPTION
## Summary

El README venía del diseño original del backend y describía piezas que ya no existen tras el refactor Fase 2+3:
- 7 estados de state machine (hoy 3)
- handlers `create_lead`/`propose_order`/`confirm_order` (eliminados)
- DAG con `intent_identified` y `order_created` (también removidos)
- `validate_action` y `available_actions` (ya no forman parte del contrato)
- `Lead`/`Order`/`OrderLineItem` como modelos ORM activos

## Cambios

- **DAG actualizado**: `product_matched` → `lead_qualified` → `shipping_info_collected` → `user_confirmed` → `payment_confirmed`.
- **Máquina de estados** colapsada a 3 (`active`, `human_handoff`, `closed`).
- **`agent/action`** descrito como persistencia de `extracted_data` con DAG gates, no como validación de acciones estructuradas.
- **Ejemplo end-to-end** coherente con el flujo real observado en DB.
- **Nueva sección "Limitaciones conocidas"** agrupada en 5 ejes (flujo/conversación, modelo de datos, integración n8n, operaciones, costos/rendimiento).
- Conteo de tests corregido (37, no 23).

**Net:** 914 → 590 líneas (-324, -35%).

## Test plan

- [x] README renderiza correctamente en GitHub (tabla de contenidos, diagramas ASCII, tablas)
- [x] Las referencias al código (ej. checkpoint names, state names, endpoints) coinciden con el estado actual del repo