### PR TITLE
refactor(007): drop dead weight + persistent customer profile

### DIFF
--- a/migrations/versions/007_drop_dead_weight_add_profile.sql
+++ b/migrations/versions/007_drop_dead_weight_add_profile.sql
@@ -1,0 +1,101 @@
+-- Migration 007: Drop dead weight + add persistent customer profile
+--
+-- Goal: every remaining column has a real use. The customer profile now
+-- persists across conversations instead of getting trapped in the per-
+-- conversation extracted_context.
+--
+-- Three things happen:
+--   1. DROP 3 dormant tables (leads, orders, order_line_items — always empty,
+--      no code path populates them after the 2026-04-19 refactor).
+--   2. DROP columns that are always NULL across all rows (audited via
+--      SELECT count(*) FILTER WHERE col IS NOT NULL per column, all returned
+--      0/N).
+--   3. ADD client_users.profile JSONB — the single place where persistent
+--      customer facts live: {first_name, full_name, email, city, address,
+--      preferences: {grind, roast}, purchase_count, purchases: [...]}.
+--   4. Tighten conversations.state CHECK to the 3 states actually used.
+--
+-- Applied: 2026-04-21
+
+-- ---------------------------------------------------------------------------
+-- 1. Dormant tables
+-- ---------------------------------------------------------------------------
+DROP TABLE IF EXISTS order_line_items CASCADE;
+DROP TABLE IF EXISTS orders CASCADE;
+DROP TABLE IF EXISTS leads CASCADE;
+
+-- ---------------------------------------------------------------------------
+-- 2. conversations: drop dead columns + tighten state CHECK
+-- ---------------------------------------------------------------------------
+ALTER TABLE conversations
+  DROP COLUMN IF EXISTS previous_state,
+  DROP COLUMN IF EXISTS lead_id,
+  DROP COLUMN IF EXISTS order_id,
+  DROP COLUMN IF EXISTS assigned_operator_id,
+  DROP COLUMN IF EXISTS escalation_reason,
+  DROP COLUMN IF EXISTS closed_at,
+  DROP COLUMN IF EXISTS agent_turn_count;
+
+ALTER TABLE conversations DROP CONSTRAINT IF EXISTS ck_conversation_state;
+ALTER TABLE conversations ADD CONSTRAINT ck_conversation_state
+  CHECK (state IN ('active', 'human_handoff', 'closed'));
+
+-- ---------------------------------------------------------------------------
+-- 3. messages: drop dead columns (idempotency handled by chakra_message_id UNIQUE)
+-- ---------------------------------------------------------------------------
+ALTER TABLE messages
+  DROP COLUMN IF EXISTS media_url,
+  DROP COLUMN IF EXISTS media_mime_type,
+  DROP COLUMN IF EXISTS delivery_status,
+  DROP COLUMN IF EXISTS delivered_at,
+  DROP COLUMN IF EXISTS read_at,
+  DROP COLUMN IF EXISTS proposed_action,
+  DROP COLUMN IF EXISTS proposed_action_payload,
+  DROP COLUMN IF EXISTS action_approved,
+  DROP COLUMN IF EXISTS backend_decision_reason,
+  DROP COLUMN IF EXISTS idempotency_key;
+
+-- ---------------------------------------------------------------------------
+-- 4. clients: drop dead columns
+-- ---------------------------------------------------------------------------
+ALTER TABLE clients
+  DROP COLUMN IF EXISTS chakra_phone_number_id,
+  DROP COLUMN IF EXISTS chakra_secret_ref,
+  DROP COLUMN IF EXISTS message_retention_days,
+  DROP COLUMN IF EXISTS max_tool_calls_per_turn;
+
+-- ---------------------------------------------------------------------------
+-- 5. client_users: drop mirror columns that were never populated,
+--    add single source-of-truth `profile` JSONB.
+-- ---------------------------------------------------------------------------
+ALTER TABLE client_users
+  DROP COLUMN IF EXISTS whatsapp_id,
+  DROP COLUMN IF EXISTS email,
+  DROP COLUMN IF EXISTS full_name,
+  DROP COLUMN IF EXISTS address,
+  DROP COLUMN IF EXISTS city,
+  DROP COLUMN IF EXISTS identification_number,
+  DROP COLUMN IF EXISTS metadata;
+
+ALTER TABLE client_users
+  ADD COLUMN IF NOT EXISTS profile JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN client_users.profile IS
+  'Persistent customer profile across conversations. Shape: '
+  '{first_name, full_name, email, city, shipping_address, '
+  'preferences: {grind, roast}, purchase_count, purchases: [{date, product_id, quantity, total}], '
+  'last_conversation_summary}. '
+  'Merged from conversations.extracted_context at agent turn close and on payment_confirmed.';
+
+-- ---------------------------------------------------------------------------
+-- 6. products: drop empty tags
+-- ---------------------------------------------------------------------------
+ALTER TABLE products DROP COLUMN IF EXISTS tags;
+
+-- ---------------------------------------------------------------------------
+-- 7. audit_log: drop columns never populated
+-- ---------------------------------------------------------------------------
+ALTER TABLE audit_log
+  DROP COLUMN IF EXISTS actor_id,
+  DROP COLUMN IF EXISTS old_value,
+  DROP COLUMN IF EXISTS metadata;

--- a/sales_agent_api/app/api/v1/agent.py
+++ b/sales_agent_api/app/api/v1/agent.py
@@ -26,7 +26,6 @@ class AgentActionRequest(BaseModel):
     conversation_id: uuid.UUID
     strategy_version: int
     response_text: str
-    proposed_action: Optional[str] = None
     proposed_transition: Optional[str] = None
     extracted_data: Optional[dict] = None
     ai_model: Optional[str] = None
@@ -72,7 +71,6 @@ async def agent_action_endpoint(
             conversation_id=body.conversation_id,
             strategy_version=body.strategy_version,
             response_text=body.response_text,
-            proposed_action=body.proposed_action,
             proposed_transition=body.proposed_transition,
             extracted_data=body.extracted_data,
             ai_model=body.ai_model,

--- a/sales_agent_api/app/api/v1/ingest.py
+++ b/sales_agent_api/app/api/v1/ingest.py
@@ -29,7 +29,6 @@ class IngestMessageRequest(BaseModel):
     content: str
     display_name: Optional[str] = None
     message_type: str = "text"
-    media_url: Optional[str] = None
     timestamp: Optional[datetime] = None
 
 
@@ -74,7 +73,6 @@ async def ingest_message_endpoint(
             content=body.content,
             display_name=body.display_name,
             message_type=body.message_type,
-            media_url=body.media_url,
             timestamp=body.timestamp,
         )
         await session.commit()

--- a/sales_agent_api/app/models/core.py
+++ b/sales_agent_api/app/models/core.py
@@ -8,7 +8,6 @@ from typing import Optional
 
 from sqlalchemy import (
     Boolean,
-    Column,
     ForeignKey,
     Integer,
     Numeric,
@@ -37,8 +36,6 @@ class Client(Base):
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     slug: Mapped[str] = mapped_column(String(100), nullable=False, unique=True)
     is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default=text("true"))
-    chakra_phone_number_id: Mapped[Optional[str]] = mapped_column(String(50))
-    chakra_secret_ref: Mapped[Optional[str]] = mapped_column(String(255))
     system_prompt_template: Mapped[Optional[str]] = mapped_column(Text)
     ai_model: Mapped[str] = mapped_column(
         String(100), nullable=False, server_default=text("'gpt-4o-mini'")
@@ -46,13 +43,9 @@ class Client(Base):
     ai_temperature: Mapped[Decimal] = mapped_column(
         Numeric(3, 2), nullable=False, server_default=text("0.3")
     )
-    max_tool_calls_per_turn: Mapped[int] = mapped_column(
-        Integer, nullable=False, server_default=text("3")
-    )
     business_rules: Mapped[dict] = mapped_column(
         JSONB, nullable=False, server_default=text("'{}'::jsonb")
     )
-    message_retention_days: Mapped[Optional[int]] = mapped_column(Integer)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=text("now()")
     )
@@ -79,13 +72,13 @@ class ClientUser(Base):
         UUID(as_uuid=True), ForeignKey("clients.id"), nullable=False
     )
     phone_number: Mapped[str] = mapped_column(String(20), nullable=False)
-    whatsapp_id: Mapped[Optional[str]] = mapped_column(String(50))
     display_name: Mapped[Optional[str]] = mapped_column(String(255))
-    email: Mapped[Optional[str]] = mapped_column(String(255))
-    full_name: Mapped[Optional[str]] = mapped_column(String(255))
-    address: Mapped[Optional[str]] = mapped_column(Text)
-    city: Mapped[Optional[str]] = mapped_column(String(100))
-    identification_number: Mapped[Optional[str]] = mapped_column(String(50))
+    # Persistent customer profile across conversations. Shape documented in
+    # migration 007: {first_name, full_name, email, city, shipping_address,
+    # preferences, purchase_count, purchases, last_conversation_summary}.
+    profile: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb")
+    )
     first_contact_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=text("now()")
     )
@@ -94,9 +87,6 @@ class ClientUser(Base):
     )
     is_blocked: Mapped[bool] = mapped_column(
         Boolean, nullable=False, server_default=text("false")
-    )
-    metadata_: Mapped[dict] = mapped_column(
-        "metadata", JSONB, nullable=False, server_default=text("'{}'::jsonb")
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=text("now()")
@@ -128,9 +118,6 @@ class Product(Base):
     is_available: Mapped[bool] = mapped_column(
         Boolean, nullable=False, server_default=text("true")
     )
-    tags: Mapped[list] = mapped_column(
-        JSONB, nullable=False, server_default=text("'[]'::jsonb")
-    )
     ai_description: Mapped[Optional[str]] = mapped_column(Text)
     image_url: Mapped[Optional[str]] = mapped_column(Text)
     created_at: Mapped[datetime] = mapped_column(
@@ -161,19 +148,15 @@ class Conversation(Base):
     state: Mapped[str] = mapped_column(
         String(30), nullable=False, server_default=text("'active'")
     )
-    previous_state: Mapped[Optional[str]] = mapped_column(String(30))
     extracted_context: Mapped[dict] = mapped_column(
         JSONB, nullable=False, server_default=text("'{}'::jsonb")
     )
-    assigned_operator_id: Mapped[Optional[str]] = mapped_column(String(100))
-    escalation_reason: Mapped[Optional[str]] = mapped_column(Text)
     started_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=text("now()")
     )
     last_message_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=text("now()")
     )
-    closed_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
     message_count: Mapped[int] = mapped_column(
         Integer, nullable=False, server_default=text("0")
     )
@@ -218,28 +201,15 @@ class Message(Base):
         String(20), nullable=False, server_default=text("'text'")
     )
     content: Mapped[Optional[str]] = mapped_column(Text)
-    media_url: Mapped[Optional[str]] = mapped_column(String(2048))
-    media_mime_type: Mapped[Optional[str]] = mapped_column(String(100))
     chakra_message_id: Mapped[Optional[str]] = mapped_column(String(100), unique=True)
-    idempotency_key: Mapped[str] = mapped_column(
-        String(100), nullable=False, server_default=text("uuid_generate_v4()::text")
-    )
-    delivery_status: Mapped[Optional[str]] = mapped_column(String(20))
-    delivered_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
-    read_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True))
     ai_model_used: Mapped[Optional[str]] = mapped_column(String(100))
     ai_prompt_tokens: Mapped[Optional[int]] = mapped_column(Integer)
     ai_completion_tokens: Mapped[Optional[int]] = mapped_column(Integer)
     ai_latency_ms: Mapped[Optional[int]] = mapped_column(Integer)
-    proposed_action: Mapped[Optional[str]] = mapped_column(String(50))
-    action_approved: Mapped[Optional[bool]] = mapped_column(Boolean)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=text("now()")
     )
-    # decision explainability (migration 002)
-    proposed_action_payload: Mapped[Optional[dict]] = mapped_column(JSONB)
     extracted_data: Mapped[Optional[dict]] = mapped_column(JSONB)
-    backend_decision_reason: Mapped[Optional[str]] = mapped_column(Text)
 
     conversation: Mapped["Conversation"] = relationship("Conversation", back_populates="messages", foreign_keys=[conversation_id])
 
@@ -260,10 +230,7 @@ class AuditLog(Base):
     entity_type: Mapped[str] = mapped_column(String(50), nullable=False)
     entity_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
     actor_type: Mapped[str] = mapped_column(String(20), nullable=False)
-    actor_id: Mapped[Optional[str]] = mapped_column(String(100))
-    old_value: Mapped[Optional[dict]] = mapped_column(JSONB)
     new_value: Mapped[Optional[dict]] = mapped_column(JSONB)
-    metadata_: Mapped[Optional[dict]] = mapped_column("metadata", JSONB)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, server_default=text("now()")
     )

--- a/sales_agent_api/app/services/agent_action.py
+++ b/sales_agent_api/app/services/agent_action.py
@@ -4,10 +4,12 @@ After the LLM produces a response, n8n calls this service to:
   1. Persist strategy-relevant extracted_data into conversation.extracted_context
      (with DAG gates to enforce data order: user_confirmation needs
      name+phone+address+city; payment_confirmation needs user_confirmation+phone+address)
-  2. Auto-escalate to human_handoff when all purchase data is collected
-  3. Apply a proposed_transition if the LLM sends one (rare)
-  4. Persist the outbound message with AI metadata
-  5. Write audit log entries
+  2. Merge stable customer facts back into client_users.profile (persistent).
+  3. On payment_confirmation, bump profile.purchase_count + append purchase record.
+  4. Auto-escalate to human_handoff when all purchase data is collected.
+  5. Apply a proposed_transition if the LLM sends one (rare).
+  6. Persist the outbound message with AI metadata.
+  7. Write audit log entries.
 """
 from __future__ import annotations
 
@@ -19,7 +21,7 @@ from typing import Optional
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.core import AuditLog, Client, Conversation, Message
+from app.models.core import AuditLog, Client, ClientUser, Conversation, Message
 from app.services.goal_strategy import GoalStrategyEngine
 from app.services.state_machine import (
     InvalidTransitionError,
@@ -31,9 +33,20 @@ logger = logging.getLogger(__name__)
 # Fields from extracted_data that are persisted to conversation.extracted_context
 # so the GoalStrategyEngine can track progress across turns.
 STRATEGY_FIELDS = {
-    "product_id", "full_name", "identification_number",
-    "email", "phone", "shipping_address", "shipping_city",
+    "product_id", "full_name", "phone",
+    "shipping_address", "shipping_city",
     "user_confirmation", "payment_confirmation",
+}
+
+# Subset of extracted_context fields that describe the person, not the
+# in-flight order — these get merged back to client_users.profile so the
+# next conversation starts already knowing them.
+PROFILE_PERSIST_MAP = {
+    "full_name": "full_name",
+    "phone": "phone",
+    "shipping_address": "shipping_address",
+    "shipping_city": "city",
+    "email": "email",
 }
 
 
@@ -55,7 +68,6 @@ async def process_agent_action(
     conversation_id: uuid.UUID,
     strategy_version: int,
     response_text: str,
-    proposed_action: Optional[str] = None,
     proposed_transition: Optional[str] = None,
     extracted_data: Optional[dict] = None,
     ai_model: Optional[str] = None,
@@ -91,8 +103,6 @@ async def process_agent_action(
             f"got {strategy_version}"
         )
 
-    current_state = conversation.state
-
     # --- 3. Persist extracted_data → extracted_context with DAG gates --------
     if extracted_data:
         strategy_updates = {
@@ -125,6 +135,14 @@ async def process_agent_action(
             conversation.extracted_context = new_context
             side_effects.append(f"context_updated:{list(strategy_updates.keys())}")
 
+            # Merge stable customer facts into the persistent profile
+            await _merge_profile(
+                session,
+                client_user_id=conversation.client_user_id,
+                extracted_context=new_context,
+                payment_just_confirmed="payment_confirmation" in strategy_updates,
+            )
+
     # --- 4. Auto-escalate when all purchase data is collected ----------------
     if conversation.state != "human_handoff":
         client_row = await session.execute(
@@ -140,11 +158,7 @@ async def process_agent_action(
             await session.execute(
                 update(Conversation)
                 .where(Conversation.id == conversation.id)
-                .values(
-                    state="human_handoff",
-                    previous_state=old_state,
-                    escalation_reason="Todos los datos de compra recopilados — listo para intervención humana",
-                )
+                .values(state="human_handoff")
             )
             conversation.state = "human_handoff"
             session.add(
@@ -154,8 +168,11 @@ async def process_agent_action(
                     entity_type="conversation",
                     entity_id=conversation.id,
                     actor_type="system",
-                    old_value={"state": old_state},
-                    new_value={"state": "human_handoff", "reason": "purchase_data_complete"},
+                    new_value={
+                        "old_state": old_state,
+                        "new_state": "human_handoff",
+                        "reason": "purchase_data_complete",
+                    },
                 )
             )
             side_effects.append("escalated:purchase_data_complete")
@@ -176,7 +193,7 @@ async def process_agent_action(
             await session.execute(
                 update(Conversation)
                 .where(Conversation.id == conversation.id)
-                .values(state=proposed_transition, previous_state=old_state)
+                .values(state=proposed_transition)
             )
             conversation.state = proposed_transition
             side_effects.append(f"state_changed:{old_state}→{proposed_transition}")
@@ -187,8 +204,7 @@ async def process_agent_action(
                     entity_type="conversation",
                     entity_id=conversation.id,
                     actor_type="agent",
-                    old_value={"state": old_state},
-                    new_value={"state": proposed_transition},
+                    new_value={"old_state": old_state, "new_state": proposed_transition},
                 )
             )
 
@@ -203,7 +219,6 @@ async def process_agent_action(
         ai_prompt_tokens=prompt_tokens,
         ai_completion_tokens=completion_tokens,
         ai_latency_ms=latency_ms,
-        proposed_action=proposed_action,
         extracted_data=extracted_data,
     )
     session.add(out_message)
@@ -216,10 +231,7 @@ async def process_agent_action(
             entity_type="message",
             entity_id=out_message.id,
             actor_type="agent",
-            new_value={
-                "proposed_action": proposed_action,
-                "side_effects": side_effects,
-            },
+            new_value={"side_effects": side_effects},
         )
     )
 
@@ -232,3 +244,54 @@ async def process_agent_action(
         "side_effects": side_effects,
         "rejection_reason": None,
     }
+
+
+async def _merge_profile(
+    session: AsyncSession,
+    client_user_id: uuid.UUID,
+    extracted_context: dict,
+    payment_just_confirmed: bool,
+) -> None:
+    """Merge stable customer facts from extracted_context into client_users.profile.
+
+    On payment_confirmation, also increments purchase_count and appends a
+    lightweight purchase record.
+    """
+    updates: dict = {}
+    for ctx_key, profile_key in PROFILE_PERSIST_MAP.items():
+        val = extracted_context.get(ctx_key)
+        if val:
+            updates[profile_key] = val
+
+    # Derive first_name from full_name if present
+    full_name = extracted_context.get("full_name")
+    if full_name:
+        updates["first_name"] = str(full_name).split()[0]
+
+    if not updates and not payment_just_confirmed:
+        return
+
+    cu_row = await session.execute(
+        select(ClientUser).where(ClientUser.id == client_user_id)
+    )
+    client_user = cu_row.scalar_one_or_none()
+    if client_user is None:
+        return
+
+    profile = dict(client_user.profile or {})
+    profile.update(updates)
+
+    if payment_just_confirmed:
+        profile["purchase_count"] = int(profile.get("purchase_count", 0)) + 1
+        purchases = list(profile.get("purchases", []))
+        purchases.append({
+            "date": datetime.now(timezone.utc).isoformat(),
+            "product_id": extracted_context.get("product_id"),
+        })
+        profile["purchases"] = purchases
+
+    await session.execute(
+        update(ClientUser)
+        .where(ClientUser.id == client_user_id)
+        .values(profile=profile)
+    )

--- a/sales_agent_api/app/services/goal_strategy.py
+++ b/sales_agent_api/app/services/goal_strategy.py
@@ -100,16 +100,11 @@ def _build_close_sale_checkpoints(business_rules: dict) -> list[Checkpoint]:
 
     # lead_qualified checkpoint — may be skipped by business rule
     if not business_rules.get("skip_lead_qualification", False):
-        lead_fields = ["full_name", "phone"]
-        if business_rules.get("require_id_number", False):
-            lead_fields.append("identification_number")
-        if business_rules.get("require_email", False):
-            lead_fields.append("email")
         checkpoints.append(
             Checkpoint(
                 name="lead_qualified",
                 label="Lead qualified",
-                required_fields=lead_fields,
+                required_fields=["full_name", "phone"],
                 blocked_by=[],
             )
         )
@@ -273,8 +268,6 @@ class GoalStrategyEngine:
         prompts = {
             "product_id": "Help the customer choose a product from the catalog.",
             "full_name": "Try to learn the customer's name.",
-            "identification_number": "Ask for the customer's ID number.",
-            "email": "Ask for the customer's email.",
             "phone": "Try to learn the customer's phone number for the carrier.",
             "shipping_address": "Try to learn the full delivery address (neighborhood, street, number, apartment).",
             "shipping_city": "Try to learn the customer's city.",

--- a/sales_agent_api/app/services/ingest.py
+++ b/sales_agent_api/app/services/ingest.py
@@ -71,7 +71,6 @@ async def ingest_message(
     content: str,
     display_name: Optional[str] = None,
     message_type: str = "text",
-    media_url: Optional[str] = None,
     timestamp: Optional[datetime] = None,
 ) -> dict:
     """Process an inbound WhatsApp message.
@@ -139,11 +138,15 @@ async def ingest_message(
     conversation: Optional[Conversation] = conv_row.scalar_one_or_none()
 
     if conversation is None:
+        # Pre-seed extracted_context from the persistent customer profile so
+        # the LLM starts a new conversation already knowing what we have on
+        # file (name, city, address, preferences, purchase history).
+        seeded_context = _seed_context_from_profile(client_user.profile or {})
         conversation = Conversation(
             client_id=client_id,
             client_user_id=client_user.id,
             state="active",
-            extracted_context={},
+            extracted_context=seeded_context,
             strategy_version=0,
         )
         session.add(conversation)
@@ -179,7 +182,6 @@ async def ingest_message(
         direction="inbound",
         message_type=message_type,
         content=content,
-        media_url=media_url,
         chakra_message_id=chakra_message_id,
         created_at=msg_timestamp,
     )
@@ -340,10 +342,7 @@ async def ingest_message(
         "user_context": {
             "display_name": client_user.display_name,
             "phone_number": _mask_phone(phone_number),
-            "has_full_name": bool(client_user.full_name),
-            "has_email": bool(client_user.email),
-            "has_address": bool(client_user.address),
-            "has_city": bool(client_user.city),
+            "profile": client_user.profile or {},
             "is_blocked": client_user.is_blocked,
         },
         "product_catalog": product_catalog,
@@ -351,15 +350,30 @@ async def ingest_message(
         "conversation_summary": format_conversation_summary(
             user_context={
                 "display_name": client_user.display_name,
-                "has_full_name": bool(client_user.full_name),
-                "has_email": bool(client_user.email),
-                "has_address": bool(client_user.address),
-                "has_city": bool(client_user.city),
+                "profile": client_user.profile or {},
             },
             extracted_context=collected_data,
         ),
         "recent_messages": recent_messages,
     }
+
+
+def _seed_context_from_profile(profile: dict) -> dict:
+    """Pull stable customer facts out of the profile into a fresh extracted_context
+    so the strategy engine already sees what we know from past conversations."""
+    if not profile:
+        return {}
+    seed: dict = {}
+    for src, dst in (
+        ("full_name", "full_name"),
+        ("email", "email"),
+        ("shipping_address", "shipping_address"),
+        ("city", "shipping_city"),
+        ("phone", "phone"),
+    ):
+        if profile.get(src):
+            seed[dst] = profile[src]
+    return seed
 
 
 def _mask_phone(phone: str) -> str:

--- a/sales_agent_api/app/services/prompt_context.py
+++ b/sales_agent_api/app/services/prompt_context.py
@@ -121,14 +121,19 @@ def format_conversation_summary(
     if display_name:
         known.append(f"display_name: {display_name}")
 
-    if user_context.get("has_full_name"):
-        known.append("full name: on file")
-    if user_context.get("has_email"):
-        known.append("email: on file")
-    if user_context.get("has_address"):
-        known.append("address: on file")
-    if user_context.get("has_city"):
-        known.append("city: on file")
+    # Persistent profile (facts carried across conversations)
+    profile = user_context.get("profile") or {}
+    for src, label in (
+        ("first_name", "first name on file"),
+        ("full_name", "full name on file"),
+        ("email", "email on file"),
+        ("city", "city on file"),
+        ("shipping_address", "shipping address on file"),
+    ):
+        if profile.get(src):
+            known.append(f"{label}: {profile[src]}")
+    if profile.get("purchase_count"):
+        known.append(f"purchase count: {profile['purchase_count']}")
 
     # From extracted_context (conversation-level data)
     for field in ("product_id", "full_name", "phone", "shipping_address",

--- a/tests/services/test_goal_strategy.py
+++ b/tests/services/test_goal_strategy.py
@@ -145,28 +145,6 @@ def test_09_skip_lead_qualification_jumps_to_shipping():
     assert "full_name" not in d.missing_fields
 
 
-def test_10_require_id_number_adds_field():
-    """require_id_number=True should add identification_number to lead_qualified."""
-    d = engine.compute(
-        "close_sale",
-        {"product_id": "abc"},
-        business_rules={"require_id_number": True},
-    )
-    assert d.current_checkpoint == "lead_qualified"
-    assert "identification_number" in d.missing_fields
-
-
-def test_11_require_email_adds_field():
-    """require_email=True should add email to lead_qualified fields."""
-    d = engine.compute(
-        "close_sale",
-        {"product_id": "abc"},
-        business_rules={"require_email": True},
-    )
-    assert d.current_checkpoint == "lead_qualified"
-    assert "email" in d.missing_fields
-
-
 # ---------------------------------------------------------------------------
 # Progress percentages
 # ---------------------------------------------------------------------------

--- a/tests/services/test_prompt_context.py
+++ b/tests/services/test_prompt_context.py
@@ -127,22 +127,23 @@ def test_summary_with_extracted_context():
     assert "shipping_city: Manizales" in result
 
 
-def test_summary_with_profile_flags():
+def test_summary_with_profile_facts():
     result = format_conversation_summary(
-        {"has_full_name": True, "has_address": True, "has_email": False, "has_city": False},
+        {"profile": {"full_name": "Juan Pérez", "shipping_address": "Calle 10 #5-20"}},
         {},
     )
-    assert "full name: on file" in result
-    assert "address: on file" in result
+    assert "full name on file: Juan Pérez" in result
+    assert "shipping address on file: Calle 10 #5-20" in result
     assert "email" not in result
 
 
 def test_summary_combines_profile_and_context():
     result = format_conversation_summary(
-        {"display_name": "Juan", "has_full_name": True},
+        {"display_name": "Juan", "profile": {"full_name": "Juan Pérez", "purchase_count": 2}},
         {"product_id": "abc", "phone": "3001234567"},
     )
     assert "Juan" in result
+    assert "purchase count: 2" in result
     assert "phone: 3001234567" in result
     assert "product_id: abc" in result
 


### PR DESCRIPTION
## Summary

- Elimina ~40 columnas siempre-NULL y 3 tablas inactivas (`leads`, `orders`, `order_line_items`) que ningún code path poblaba.
- Reemplaza las columnas espejo de `client_users` (full_name/email/address/city/metadata, nunca persistidas) por un único `profile JSONB` que **sobrevive entre conversaciones**.
- Aprieta `ck_conversation_state` a los 3 estados reales: `active`, `human_handoff`, `closed`.
- Primera pieza del plan — Rama 2 (palanca A: cómo se comunica el contexto al LLM) va aparte.

## Migration 007 — schema

- DROP tables: `leads`, `orders`, `order_line_items` (CASCADE, 0 filas en todas)
- `conversations`: DROP `previous_state`, `lead_id`, `order_id`, `assigned_operator_id`, `escalation_reason`, `closed_at`, `agent_turn_count`; tighten CHECK a 3 estados
- `messages`: DROP `media_url`, `media_mime_type`, `delivery_status`, `delivered_at`, `read_at`, `proposed_action`, `proposed_action_payload`, `action_approved`, `backend_decision_reason`, `idempotency_key`
- `clients`: DROP `chakra_phone_number_id`, `chakra_secret_ref`, `message_retention_days`, `max_tool_calls_per_turn`
- `client_users`: DROP `whatsapp_id`, `email`, `full_name`, `address`, `city`, `identification_number`, `metadata`; ADD `profile JSONB NOT NULL DEFAULT '{}'`
- `products`: DROP `tags`
- `audit_log`: DROP `actor_id`, `old_value`, `metadata`

## Customer persistence — cómo queda

`client_users.profile` es ahora la única fuente de verdad, con esta shape documentada:

```json
{
  "first_name": "...",
  "full_name": "...",
  "email": "...",
  "city": "...",
  "shipping_address": "...",
  "preferences": {"grind": "...", "roast": "..."},
  "purchase_count": 0,
  "purchases": [{"date": "...", "product_id": "..."}],
  "last_conversation_summary": "..."
}
```

Dos puntos de merge:

1. **Ingest** (`ingest.py`): al crear una conversación nueva, `extracted_context` se pre-carga con los campos estables del `profile` (full_name, email, shipping_address, city, phone). El cliente que regresa no arranca en cero.
2. **Agent action** (`agent_action.py`): en cada turno, los datos estables del `extracted_context` se persisten al `profile`. Al confirmar pago (`payment_confirmation`), se incrementa `purchase_count` y se agrega un registro a `purchases`.

## Code changes

- `models/core.py` alineado al nuevo schema
- `ingest.py`: pre-seed del profile + elimina `media_url`
- `agent_action.py`: profile merge-back + purchase count + elimina writes a `previous_state` / `escalation_reason` (columnas eliminadas)
- `api/v1/agent.py`: elimina `proposed_action` del request schema (nunca producido por el LLM)
- `api/v1/ingest.py`: elimina `media_url` del request
- `goal_strategy.py`: elimina branches `require_id_number` / `require_email` (nunca activadas, sus campos nunca persistían)
- `prompt_context.py`: `format_conversation_summary` lee el `profile` en vez de los flags `has_*`
- Tests actualizados — 30/30 en verde

## Test plan

- [x] `pytest tests/services/` — 30/30 pasan
- [x] Imports limpios (`app.main`, ORM, servicios, routers)
- [ ] **Aplicar migración 007 en prod** (después del merge)
- [ ] **TRUNCATE `audit_log`, `messages`, `conversations`** (limpiar historial, preservar `clients`, `products`, `client_users.profile = '{}'`)
- [ ] Smoke test: mensaje entrante → respuesta → mensaje de segunda conversación debe ver el profile precargado
- [ ] Verificar que `payment_confirmation` bumpea `purchase_count`

🤖 Generated with [Claude Code](https://claude.com/claude-code)