### PR TITLE
feat(prompt-context): añade quantity y grind_preference al estado del pedido

### DIFF
--- a/sales_agent_api/app/services/prompt_context.py
+++ b/sales_agent_api/app/services/prompt_context.py
@@ -110,6 +110,8 @@ def format_business_context(
 # (clave en extracted_context, etiqueta humana, etiqueta corta para "FALTA").
 _ORDER_FIELDS: tuple[tuple[str, str, str], ...] = (
     ("product_id",          "Producto",             "producto"),
+    ("quantity",            "Cantidad",             "cantidad (número de bolsas)"),
+    ("grind_preference",    "Preferencia de molido","preferencia de molido (grano/molido)"),
     ("full_name",           "Nombre completo",      "nombre completo"),
     ("phone",               "Teléfono",             "teléfono"),
     ("shipping_city",       "Ciudad",               "ciudad"),

--- a/tests/services/test_prompt_context.py
+++ b/tests/services/test_prompt_context.py
@@ -182,6 +182,8 @@ def test_summary_all_complete():
         {},
         {
             "product_id": "abc",
+            "quantity": 4,
+            "grind_preference": "2 molidos y 2 en grano",
             "full_name": "Juan Pérez",
             "phone": "3001234567",
             "shipping_city": "Manizales",
@@ -192,6 +194,21 @@ def test_summary_all_complete():
     )
     assert "Todos los datos del pedido están completos" in result
     assert "✗" not in result
+
+
+def test_summary_shows_quantity_and_grind_when_collected():
+    result = format_conversation_summary(
+        {},
+        {"product_id": "abc", "quantity": 4, "grind_preference": "grano"},
+    )
+    assert "✓ Cantidad: 4" in result
+    assert "✓ Preferencia de molido: grano" in result
+
+
+def test_summary_missing_quantity_and_grind():
+    result = format_conversation_summary({}, {"product_id": "abc"})
+    assert "✗ cantidad (número de bolsas)" in result
+    assert "✗ preferencia de molido (grano/molido)" in result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Añade `quantity` y `grind_preference` a `_ORDER_FIELDS` para que aparezcan con ✓/✗ en el bloque `=== ESTADO DEL PEDIDO ===`.
- Parte de un set coordinado de cambios para arreglar el resumen (cantidad perdida, molido no preguntado) observado en la conversación del 22-abr 07:04-07:11.
- Los cambios complementarios ya están aplicados: system_prompt actualizado con reglas de extracción nuevas (ciudad/acá, saludo social, uso del nombre, schema ampliado), y n8n `Build LLM Prompt` amplía la lista de keys válidas (`quantity`, `grind_preference`, `roast_preference`).

## Test plan
- [x] `pytest tests/services/test_prompt_context.py tests/services/test_goal_strategy.py` → 35/35 verdes localmente.
- [ ] Tras merge + auto-deploy, verificar conversación end-to-end:
  - Cliente dice "3 en grano, 2 molidos" → `quantity=5` y `grind_preference="3 en grano y 2 molidos"` aparecen en `extracted_context`.
  - Cliente dice "Para Manizales" temprano → `shipping_city="Manizales"` se captura inmediatamente.
  - Cliente responde "acá" en otro turno → NO sobrescribe Manizales.
  - Resumen final muestra cantidad correcta y envío de \$7.000 para Manizales.

🤖 Generated with [Claude Code](https://claude.com/claude-code)