### PR TITLE
docs: add sales-ai-docs with architecture docs, ADRs, and Mermaid dia…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Claude Code — contexto operacional, no se commitea
+/CLAUDE.md
+.claude/
+.claude-cache/
+
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+venv/
+dist/
+build/
+.eggs/
+
+# Environment
+.env
+.env.*
+!.env.example
+
+# OS
+.DS_Store

--- a/sales-ai-docs/.gitignore-additions
+++ b/sales-ai-docs/.gitignore-additions
@@ -1,0 +1,13 @@
+# ─────────────────────────────────────────────────────────────────
+# Líneas a AGREGAR al .gitignore existente del repo
+# (no reemplazar — solo añadir al final si no están)
+# ─────────────────────────────────────────────────────────────────
+
+# Claude Code — contexto operacional, no se commitea
+CLAUDE.md
+.claude/
+.claude-cache/
+
+# Notas locales del equipo (si las llegas a tener)
+NOTES.local.md
+TODO.local.md

--- a/sales-ai-docs/CLAUDE.md
+++ b/sales-ai-docs/CLAUDE.md
@@ -1,0 +1,236 @@
+# CLAUDE.md — Sales AI Agent Backend
+
+> **Este archivo es contexto operacional para Claude Code. Vive en la raíz del repo, está en `.gitignore`, y debe reflejar SIEMPRE el estado actual del sistema.**
+>
+> Para entender el *por qué* de las decisiones, leer `docs/decisions/`. Para entender la arquitectura conceptual, leer `docs/architecture/overview.md`.
+
+---
+
+## Qué es esto
+
+Backend de ventas por WhatsApp multi-tenant. **El LLM conversa, el backend gobierna.** El LLM (gpt-4o-mini vía OpenAI) genera lenguaje natural y propone slots de datos. El backend valida cada propuesta contra reglas deterministas antes de persistir.
+
+Stack: FastAPI (async) + PostgreSQL 16 + asyncpg/SQLAlchemy 2.0. Azure Container Apps. n8n orquesta WhatsApp ↔ Backend ↔ LLM. Chakra HQ maneja la API de WhatsApp.
+
+---
+
+## Arquitectura en 3 capas
+
+```mermaid
+graph TB
+    subgraph C1["Capa 1 — Lenguaje"]
+        LLM["LLM · gpt-4o-mini\nNLU + NLG · sin tools · sin loops · sin estado"]
+    end
+    subgraph C2["Capa 2 — Política"]
+        POL["GoalStrategyEngine · DAG gates · state machine"]
+    end
+    subgraph C3["Capa 3 — Dominio"]
+        DB["PostgreSQL · ground truth"]
+    end
+    C2 -- directiva --> C1
+    C1 -- extracted_data --> C2
+    C3 -- contexto --> C2
+    C2 -- slots aceptados --> C3
+```
+
+Cada turno = 2 HTTP calls de n8n al backend, 1 LLM call al medio. Sin tool-calling, sin agent loops.
+
+---
+
+## Schema de DB actual (post-migration 007)
+
+7 tablas activas. NO existen `leads`, `orders`, `order_line_items` (dropeadas en 007 — ver ADR-004).
+
+```
+clients              tenant boundary
+client_users         end customers + profile JSONB persistente
+products             catálogo por client
+conversations        sesión de chat + extracted_context JSONB + strategy_*
+messages             trail de mensajes con metadatos AI
+audit_log            eventos append-only
+```
+
+**Reglas de schema**:
+- Toda tabla tenant-facing tiene `client_id UUID NOT NULL FK` no nulable
+- ENUMs como `VARCHAR + CHECK CONSTRAINT` (no native ENUMs — ver ADR-006)
+- Toda query debe filtrar por `client_id` (multi-tenant por aplicación, no RLS — deuda)
+- Triggers de `updated_at` en clients/client_users/products/conversations
+- Idempotencia de mensajes vía `messages.chakra_message_id UNIQUE`
+
+---
+
+## Estado conversacional
+
+3 estados actuales (post-refactor 2026-04-19 — ver ADR-007):
+
+```mermaid
+stateDiagram-v2
+    [*] --> active
+    active --> human_handoff : DAG completo (auto-escalate)
+    active --> closed
+    human_handoff --> active : operador interviene
+    human_handoff --> closed
+    closed --> [*]
+```
+
+Toda conversación nueva nace en `active`. Auto-escala a `human_handoff` cuando todos los checkpoints del DAG están completos. `closed` es terminal.
+
+---
+
+## DAG de close_sale (vigente)
+
+```mermaid
+graph TD
+    A["📦 product_matched\nproduct_id"]
+    B["👤 lead_qualified\nfull_name · phone"]
+    C["🏠 shipping_info_collected\nshipping_address · shipping_city"]
+    D["✅ user_confirmed\nuser_confirmation\n⚡ gate: full_name + phone + shipping_address + shipping_city"]
+    E["💳 payment_confirmed\npayment_confirmation\n⚡ gate: user_confirmed + phone + shipping_address"]
+    F(["🤝 auto-escalate → human_handoff"])
+
+    A --> B --> C --> D --> E --> F
+```
+
+NO existen `intent_identified` ni `order_created` (removidos — ver ADR-008 cuando se escriba).
+
+**DAG gates en `agent_action.py`**:
+- `user_confirmation` requiere full_name + phone + shipping_address + shipping_city presentes
+- `payment_confirmation` requiere user_confirmation + phone + shipping_address presentes
+- Si el gate rechaza un slot, la respuesta del LLM al usuario igual se envía (fail-safe)
+
+---
+
+## El patrón de dos llamadas
+
+```mermaid
+sequenceDiagram
+    participant W as WhatsApp
+    participant N as n8n
+    participant B as Backend FastAPI
+    participant L as LLM (gpt-4o-mini)
+    participant DB as PostgreSQL
+
+    W->>N: Webhook Chakra · mensaje del cliente
+
+    N->>B: POST /api/v1/ingest/message
+    B->>DB: Validar client · idempotencia · bloqueo de usuario
+    B->>DB: Upsert client_user · find/create conversación (24h)
+    B->>DB: Advisory lock · persistir mensaje inbound
+    Note over B: Debounce 5s — DEUDA técnica
+    B->>B: GoalStrategyEngine → directive
+    B->>DB: Bump strategy_version · persistir snapshot
+    B-->>N: directive · strategy_version · business_context · recent_messages
+
+    N->>L: system prompt + directive + historial (1 sola llamada, sin tools)
+    L-->>N: response_text + extracted_data
+
+    N->>B: POST /api/v1/agent/action
+    B->>B: Verificar strategy_version (409 si stale — ADR-003)
+    B->>B: DAG gates → merge extracted_data
+    B->>DB: Sync stable facts → client_users.profile
+    B->>DB: Auto-escalate si all_complete · persistir outbound + audit_log
+    B-->>N: approved · final_response_text · side_effects
+
+    N->>W: final_response_text via Chakra
+```
+
+---
+
+## Reglas de modificación
+
+**Cuando crear una migración** (`migrations/versions/NNN_*.sql`):
+- Cambio de schema de cualquier tabla
+- Cambio de seed data del cliente demo (Café Arenillo)
+- Cambio del `system_prompt_template` de un cliente
+- Cambio de `business_rules` JSONB que afecta comportamiento del bot
+
+Numeración secuencial. NO modificar migraciones ya aplicadas — siempre crear una nueva.
+
+**Cuando crear un ADR** (`docs/decisions/ADR-NNN-*.md`):
+- Decisión arquitectónica que alguien preguntará en 6 meses por qué la tomamos
+- Adopción/abandono de una librería
+- Cambio en patrón de seguridad/auth
+- Drop de tabla, columna o feature significativa
+
+**Cuando NO modificar este archivo**:
+- Si la decisión va a un ADR y el estado actual no cambia, basta con el ADR
+- Para historia, justificaciones largas, alternativas consideradas → ADR
+
+**Cuando SÍ modificar este archivo**:
+- Cambio en arquitectura de capas, schema activo, estado de DAG, estados de conversación
+- Aparece nueva pieza operacional (job nocturno, integración nueva, etc.)
+- Cambio en convenciones de código
+
+---
+
+## Convenciones de código
+
+- **Async everywhere**: SQLAlchemy 2.0 async, asyncpg, FastAPI async endpoints
+- **Type hints obligatorios** en signatures de servicios (no en helpers triviales)
+- **Pydantic** para todo request/response schema
+- **Logging estructurado**, nunca PII en plaintext
+- **Constant-time comparisons** para tokens (`hmac.compare_digest`)
+- **Tenant filtering** en TODA query (`WHERE client_id = ...`)
+- **PII masking** en logs (ver `_mask_phone` en `ingest.py`)
+
+**Estructura de servicios**:
+- `services/` = lógica pura, testeable sin red ni DB cuando posible
+- `api/v1/` = endpoints FastAPI delgados, delegan a servicios
+- `models/` = ORM SQLAlchemy
+- `core/` = configuración, DB, auth
+
+**Tests**:
+- `tests/services/` = pure-python, rápidos, corren en cada commit
+- `tests/integration/` = contra Postgres real, corren antes de mergear (DEUDA: no existen aún)
+
+---
+
+## Deuda técnica visible
+
+| # | Item | Severidad | Bloquea cliente que paga? |
+|---|------|-----------|---------------------------|
+| 1 | Sin tests de integración (cero contra Postgres) | Alta | Sí |
+| 2 | Debounce con `asyncio.sleep(5)` durante transacción ocupa pool | Alta | A medio plazo |
+| 3 | Sin telemetría (no hay alertas de fallas silenciosas n8n→backend) | Alta | Sí |
+| 4 | Sin vista de operador para human_handoff | Crítica | Sí |
+| 5 | Multi-tenant defendido por aplicación, no por RLS | Media | Al 3er cliente |
+| 6 | Auth: un solo token compartido sin rotación ni scopes | Media | Al escalar callers |
+| 7 | Bug de re-saludo después de N días (extracted_context se pierde entre conversaciones) | Media | Notable pero no bloqueador |
+| 8 | LLM puede inventar formatos en extracted_data (sin structured output) | Media | Sí, si no se ataja |
+| 9 | Sin pruebas de carga — desconocemos throughput máximo | Alta | Sí (no se puede ofrecer SLA) |
+| 10 | Reset de extracted_context por idle 30 min puede borrar contexto legítimo | Baja | No |
+
+**Próximo trabajo prioritario** (ver `docs/decisions/` cuando se decida):
+- Fase 0: structured output (Pydantic + response_format), tests de integración, load test
+- Fase 1: tabla `purchase_intents` para preservar venta entre conversaciones
+- Fase 2: front de operador (3 pantallas: inbox, dashboard, config)
+
+---
+
+## Producción actual
+
+| Componente | Detalle |
+|------------|---------|
+| Backend URL | `https://<CONTAINER_APP>.azurecontainerapps.io` |
+| Postgres | `<POSTGRES_HOST>.postgres.database.azure.com` / DB `sales_ai` |
+| Key Vault | `<KEY_VAULT_NAME>` (DBUSERNAME, DBPASSWORD, DBHOST, DBNAME, sales-ai-service-token) |
+| Managed Identity | `<MANAGED_IDENTITY_NAME>` |
+| n8n | `<N8N_CONTAINER_APP>.azurecontainerapps.io` |
+| Cliente demo | Café Arenillo — `00000000-0000-0000-0000-000000000001` |
+| CI/CD | Push a `main` → GitHub Actions → tests + Docker build → ACR push → Container App update |
+
+---
+
+## Glosario rápido
+
+- **client** = tenant (un negocio que usa la plataforma, ej. Café Arenillo)
+- **client_user** = end customer (quien escribe por WhatsApp al negocio)
+- **conversation** = sesión de chat con ventana de 24h
+- **extracted_context** = JSONB en `conversations` con datos recolectados por turno
+- **profile** = JSONB en `client_users` con datos persistentes entre conversaciones
+- **strategy_version** = entero que se incrementa en cada `/ingest`, valida no-staleness en `/agent/action`
+- **directive** = bloque de texto que el GoalStrategyEngine genera para guiar al LLM
+- **DAG gate** = validación previa al merge de un slot en extracted_context
+- **side_effects** = lista de strings descriptivos en la respuesta de `/agent/action`
+
+Para definiciones extendidas, ver `docs/architecture/glossary.md`.

--- a/sales-ai-docs/README-INSTALL.md
+++ b/sales-ai-docs/README-INSTALL.md
@@ -1,0 +1,100 @@
+# Documentación de Sales AI Agent — paquete inicial
+
+Este paquete contiene la documentación inicial del proyecto. Está organizado para copiarse directamente sobre tu repositorio local manteniendo la estructura de directorios.
+
+---
+
+## Contenido
+
+```
+.
+├── README-INSTALL.md                ← este archivo (no copiar al repo)
+├── .gitignore-additions             ← líneas a agregar al .gitignore (no copiar tal cual)
+│
+├── CLAUDE.md                        ← copiar a la raíz del repo (gitignored)
+│
+└── docs/                            ← copiar tal cual al repo (committed)
+    ├── README.md
+    ├── architecture/
+    │   ├── overview.md
+    │   └── glossary.md
+    └── decisions/
+        ├── README.md
+        ├── ADR-001-dag-over-search.md
+        ├── ADR-002-no-tools-pattern.md
+        ├── ADR-003-strategy-version.md
+        ├── ADR-004-drop-leads-orders.md
+        ├── ADR-005-persistent-profile.md
+        ├── ADR-006-varchar-check-over-enums.md
+        └── ADR-007-state-machine-collapse.md
+```
+
+---
+
+## Instalación en tu repo local
+
+Suponiendo que descomprimiste este paquete en `~/Downloads/sales-ai-docs/` y tu repo está en `~/code/agent-backend/`:
+
+```bash
+cd ~/code/agent-backend
+
+# 1. Copiar CLAUDE.md a la raíz del repo
+cp ~/Downloads/sales-ai-docs/CLAUDE.md .
+
+# 2. Copiar la carpeta docs/ tal cual
+cp -r ~/Downloads/sales-ai-docs/docs .
+
+# 3. Agregar líneas al .gitignore (NO reemplazar — solo añadir)
+cat ~/Downloads/sales-ai-docs/.gitignore-additions >> .gitignore
+
+# 4. Verificar que git NO ve CLAUDE.md
+git status
+# debe mostrar:
+#   modified:   .gitignore
+#   new file:   docs/README.md
+#   new file:   docs/architecture/...
+#   ... (pero NO CLAUDE.md)
+
+# 5. Commitear todo MENOS CLAUDE.md
+git add .gitignore docs/
+git commit -m "docs: initial documentation package — ADRs, overview, glossary"
+
+# 6. Confirmar que CLAUDE.md vive solo en local
+ls -la CLAUDE.md   # debe existir
+git log -- CLAUDE.md   # debe estar vacío (nunca committed)
+```
+
+---
+
+## Cómo usar esto día a día
+
+**Cuando Claude Code arranque una sesión**, va a leer `CLAUDE.md` automáticamente. Es contexto operacional vivo: reflejará siempre el estado actual del sistema.
+
+**Cuando escribas código nuevo o tomes decisiones**, segui estos triggers:
+
+1. **Migración de DB nueva** → revisar `CLAUDE.md`, sección de schema, actualizar si hace falta.
+2. **Decisión arquitectónica importante** → escribir un ADR nuevo. Numerado secuencial.
+3. **Drop de funcionalidad o tabla** → actualizar `CLAUDE.md` + posible ADR.
+4. **Incidente con impacto a usuario** → escribir postmortem en `docs/postmortems/`.
+
+**Cuando alguien nuevo entre al proyecto**:
+1. Leer `docs/architecture/overview.md` (15 minutos)
+2. Hojear `docs/decisions/` por orden cronológico (30-60 minutos)
+3. Trabajar con `CLAUDE.md` abierto al lado del código
+
+---
+
+## Plantilla para ADR nuevo
+
+Cuando tomes una decisión nueva, copia el template de `docs/decisions/README.md`. El próximo ADR sería **ADR-008**.
+
+Casos esperados pronto:
+- ADR-008: tabla `purchase_intents` para preservar venta entre conversaciones
+- ADR-009: structured output con Pydantic + response_format
+- ADR-010: front de operador como producto separado
+
+---
+
+## Si algo se siente mal
+
+La documentación es viva. Si encontrás que CLAUDE.md tiene algo desactualizado, arreglalo en el momento. Si un ADR vieje quedó superado, **NO lo borres** — escribí uno nuevo que lo "supersede". El historial inmutable es parte del valor.

--- a/sales-ai-docs/docs/README.md
+++ b/sales-ai-docs/docs/README.md
@@ -1,0 +1,56 @@
+# Documentación — Sales AI Agent
+
+Esta carpeta contiene documentación versionada del proyecto. **Lo que NO está aquí pero sí se usa**: `CLAUDE.md` en la raíz del repo (gitignored, contexto operacional para Claude Code).
+
+---
+
+## Cómo navegar
+
+| Si buscas... | Ve a... |
+|---|---|
+| Estado actual del sistema (qué es esto hoy) | `../CLAUDE.md` |
+| Por qué decidimos algo | `decisions/` (ADRs) |
+| Cómo está pensada la arquitectura | `architecture/overview.md` |
+| Definiciones de términos del dominio | `architecture/glossary.md` |
+| Cómo desplegar, hacer rollback, debugear | `runbooks/` |
+| Qué pasó en un incidente y qué aprendimos | `postmortems/` |
+
+---
+
+## Filosofía de documentación
+
+**Tres tipos de documentos, tres propósitos**:
+
+1. **Operacional** (`CLAUDE.md`): qué es el sistema HOY. Vive, se actualiza, no tiene historia.
+2. **Histórico** (`decisions/`): por qué tomamos cada decisión. Append-only, fechado, inmutable.
+3. **Conceptual** (`architecture/`): cómo está pensado el sistema. Cambia raramente.
+
+**Triggers de actualización**:
+
+- Cada migración de DB → revisar `CLAUDE.md` (sección de schema)
+- Cada drop de funcionalidad → actualizar `CLAUDE.md` + posible ADR
+- Cada decisión que en 6 meses alguien preguntará "por qué" → ADR nuevo
+- Cada incidente con impacto en usuario → postmortem
+
+---
+
+## Estado actual de docs
+
+```
+docs/
+├── README.md                   ← este archivo
+├── architecture/
+│   ├── overview.md             ← (pendiente)
+│   └── glossary.md             ← (pendiente)
+├── decisions/
+│   ├── README.md               ← índice de ADRs + plantilla
+│   ├── ADR-001-dag-over-search.md
+│   ├── ADR-002-no-tools-pattern.md
+│   ├── ADR-003-strategy-version.md
+│   ├── ADR-004-drop-leads-orders.md
+│   ├── ADR-005-persistent-profile.md
+│   ├── ADR-006-varchar-check-over-enums.md
+│   └── ADR-007-state-machine-collapse.md
+├── runbooks/                   ← vacío hoy, llenar cuando aparezca necesidad
+└── postmortems/                ← vacío hoy
+```

--- a/sales-ai-docs/docs/architecture/glossary.md
+++ b/sales-ai-docs/docs/architecture/glossary.md
@@ -1,0 +1,110 @@
+# Glosario
+
+Términos y conceptos del dominio Sales AI Agent. Cuando aparece un término en código, prompt, ADR o discusión, esta es la definición canónica.
+
+---
+
+## Términos del modelo de datos
+
+**client**
+Tenant. Un negocio que usa la plataforma Sales AI Agent. Cada `client` tiene su propia configuración (`system_prompt_template`, `business_rules`, `ai_model`), su propio catálogo de productos, sus propios usuarios finales. Ejemplo en producción hoy: Café Arenillo (UUID de seed data en migración 001).
+
+**client_user**
+End customer. La persona que escribe por WhatsApp al negocio del cliente. Identificado únicamente por la combinación `(client_id, phone_number)` — la misma persona puede ser cliente de dos negocios distintos en la plataforma sin colisión.
+
+**conversation**
+Sesión de chat entre un `client_user` y el bot. Tiene una ventana de validez de 24 horas: si pasaron 24h sin mensajes, una nueva conversación se crea. Si pasaron 30+ minutos sin mensajes pero menos de 24h, se mantiene la conversación pero se resetea `extracted_context` (decisión defensiva contra contexto contaminado de hace mucho).
+
+**message**
+Cada interacción individual. `direction` puede ser `inbound` (cliente → bot) u `outbound` (bot → cliente). Tiene `chakra_message_id` único para idempotencia.
+
+**product**
+Item del catálogo del cliente. Tiene precio que el LLM **nunca puede modificar** — el precio que el bot menciona en respuestas viene del prompt (que el backend arma con el catálogo), pero ninguna mutación de DB usa precios propuestos por el LLM.
+
+---
+
+## Términos del dominio conversacional
+
+**extracted_context**
+Campo JSONB en `conversations`. Contiene los slots de datos recolectados durante la conversación actual. Estructura típica:
+```json
+{
+  "product_id": "<uuid>",
+  "full_name": "Juan Pérez",
+  "phone": "3001234567",
+  "shipping_city": "Manizales",
+  "shipping_address": "Calle 10 #5-20",
+  "user_confirmation": true,
+  "payment_confirmation": true
+}
+```
+Vive durante la conversación; se pierde si la conversación expira (limitación conocida).
+
+**profile**
+Campo JSONB en `client_users`. Contiene datos persistentes del cliente entre conversaciones: nombre, dirección, ciudad, preferencias, historial de compras. Se sincroniza desde `extracted_context` cuando se aceptan slots estables. Ver ADR-005.
+
+**directive (strategy_directive)**
+Bloque de texto generado por el `GoalStrategyEngine` que se inyecta en el system prompt del LLM. Contiene: progreso del DAG, próximo dato a recolectar, hint conversacional. No es una orden — es una guía suave que el LLM debe respetar pero sin sacrificar la conversación natural.
+
+**strategy_version**
+Entero monotónicamente creciente en `conversations`. Se incrementa en cada `/ingest/message`. Sirve para detectar contexto viejo entre las dos llamadas del turno. Ver ADR-003.
+
+**DAG gate**
+Validación previa al merge de un slot en `extracted_context`. Implementada en `agent_action.py`. Verifica precondiciones de orden lógico (no se puede confirmar pago sin haber confirmado pedido, no se puede confirmar pedido sin tener nombre+teléfono+dirección+ciudad). Si rechaza, el slot no se persiste pero la conversación continúa.
+
+**side_effects**
+Lista de strings descriptivos que `/agent/action` devuelve a n8n. Permiten que el orquestador conozca consecuencias de la transacción sin tener que parsear estado. Ejemplos: `context_updated:['full_name','phone']`, `escalated:purchase_data_complete`, `warning:premature_summary_missing_phone+shipping_city`.
+
+---
+
+## Términos del flujo
+
+**ingest call (Llamada 1)**
+`POST /api/v1/ingest/message`. Procesa mensaje entrante, computa estrategia, devuelve contexto para que n8n llame al LLM.
+
+**agent action call (Llamada 2)**
+`POST /api/v1/agent/action`. Recibe lo que el LLM produjo, valida, persiste, devuelve respuesta final aprobada.
+
+**checkpoint**
+Nodo del DAG. Representa "información suficiente sobre algo". Cada checkpoint tiene `required_fields` (qué slots de `extracted_context` deben estar presentes) y `blocked_by` (qué otros checkpoints deben estar completos antes).
+
+**status de checkpoint**
+Cuatro estados posibles: `complete` (todos los fields presentes), `blocked` (dependencias no completas), `in_progress` (algunos fields presentes), `pending` (sin fields, sin bloqueo).
+
+**all_complete**
+Booleano. Verdadero cuando todos los checkpoints del DAG actual están en estado `complete`. Dispara auto-escalate a `human_handoff`.
+
+**auto-escalate**
+Transición automática de `active → human_handoff` cuando `all_complete` se cumple. No requiere intervención del LLM — es una consecuencia determinística del estado del DAG.
+
+**debounce**
+Mecanismo en `ingest.py` que espera 5 segundos tras commitear un mensaje para verificar si llegó otro. Si llegó uno nuevo, este turno no responde (`should_respond=false`). Mitiga ráfagas rápidas de mensajes del mismo cliente.
+
+**advisory lock**
+`pg_advisory_xact_lock(hash(conversation_id))`. Lock de PostgreSQL a nivel de transacción que serializa procesamiento de mensajes de la misma conversación. Se libera con commit/rollback.
+
+---
+
+## Términos de integración
+
+**Chakra HQ**
+Proveedor de WhatsApp Business API. Maneja la complejidad de Meta Business, plantillas, opt-in, etc. Recibe webhooks y los manda a n8n.
+
+**n8n**
+Orquestador de workflows. Recibe webhook de Chakra, llama `/ingest`, llama LLM, llama `/agent/action`, manda respuesta final a Chakra. No tiene lógica de negocio — solo enrutamiento.
+
+**Llamada al LLM**
+Hoy: OpenAI gpt-4o-mini. Configurable por cliente vía `clients.ai_model` y `clients.ai_temperature`.
+
+---
+
+## Términos de operación
+
+**human_handoff**
+Estado de la conversación cuando el bot ya no responde y se espera intervención humana. Hoy se llega ahí solo por auto-escalate (DAG completo). En el futuro podrá llegarse también por timeout, por escalamiento explícito del LLM, o por acción del operador.
+
+**purchase intent (futuro)**
+Entidad pendiente de implementación. Va a representar una venta en curso que persiste entre conversaciones para resolver el bug de pérdida de carrito. Pendiente de ADR-008.
+
+**operator (futuro)**
+Persona del lado del cliente (negocio) que atiende las conversaciones escaladas. Hoy es típicamente el dueño del negocio o un empleado de ventas. La vista de operador es prerequisito de venta del producto — pendiente en roadmap.

--- a/sales-ai-docs/docs/architecture/overview.md
+++ b/sales-ai-docs/docs/architecture/overview.md
@@ -1,0 +1,173 @@
+# Arquitectura — Overview
+
+Este documento responde a la pregunta **"¿cómo está pensado este sistema?"**. Para el estado actual operacional, leer `../../CLAUDE.md`. Para el por qué de cada decisión, leer `../decisions/`.
+
+---
+
+## La idea fundamental
+
+> **El LLM conversa, el backend gobierna.**
+
+La mayoría de los chatbots de WhatsApp delegan al LLM no solo la generación de lenguaje sino también las decisiones de negocio: cuándo crear un lead, cuándo proponer un producto, cuándo cerrar una venta. Eso funciona hasta que no funciona — el LLM es probabilístico y las reglas de negocio no lo son.
+
+Sales AI Agent invierte esa relación. El LLM solo entiende y produce lenguaje natural. Todas las decisiones — qué pedir, cuándo escalar, qué dato es admisible — viven en código Python testeable. El LLM **propone**; el backend **valida y ejecuta**.
+
+---
+
+## Las tres capas
+
+```mermaid
+graph TB
+    subgraph C1["Capa 1 — Lenguaje"]
+        LLM["LLM · gpt-4o-mini\nNLU + NLG · sin tools · sin loops · sin estado\n─────────────────────────────────────\nLee: texto del cliente · system prompt · directiva\nEscribe: response_text · extracted_data\nDecide: nada de la venta"]
+    end
+    subgraph C2["Capa 2 — Política"]
+        POL["GoalStrategyEngine · DAG gates · state machine\n─────────────────────────────────────\nLee: extracted_context · business_rules\nEscribe: directiva del turno · accept/reject por slot\nDecide: orden de pedidos · cuándo escalar · qué admisible"]
+    end
+    subgraph C3["Capa 3 — Dominio"]
+        DB["PostgreSQL\nclients · client_users · conversations · messages\n─────────────────────────────────────\nSource of truth · tenant config · perfil · historial\nDecide: nada — es ground truth"]
+    end
+    C2 -- directiva del turno --> C1
+    C1 -- extracted_data propuesto --> C2
+    C3 -- load context --> C2
+    C2 -- persist accepted slots --> C3
+```
+
+**Propiedad clave**: el LLM es la pieza más reemplazable del sistema. Si mañana sale un modelo mejor, se cambia el string del modelo en `clients.ai_model`. Los datos recolectados viven en Postgres, no en el contexto del modelo.
+
+---
+
+## Ubicación en el espacio de arquitecturas
+
+Para ubicar esto frente a otros sistemas conversacionales:
+
+```mermaid
+quadrantChart
+    title Espacio de arquitecturas conversacionales
+    x-axis Baja especificidad de dominio --> Alta especificidad de dominio
+    y-axis Baja autonomía del LLM --> Alta autonomía del LLM
+    Agentes ReAct / AutoGPT: [0.18, 0.92]
+    Bland AI / ElevenLabs Conversational: [0.50, 0.72]
+    Sales AI Agent ★ tú estás aquí: [0.85, 0.48]
+    Dialogflow / Watson / Rasa NLU: [0.82, 0.18]
+```
+
+**Lo que tenemos NO es un agente clásico** (estilo ReAct/AutoGPT). En la literatura más cercana, este patrón se conoce como **information-state dialogue manager** (Larsson & Traum, 2000) — un manejador de diálogo cuyo estado es la información acumulada — modernizado con un LLM haciendo NLU/NLG. Comercialmente, el primo más cercano es **Rasa CALM**.
+
+---
+
+## El DAG de close_sale
+
+```mermaid
+graph TD
+    A["📦 product_matched\nproduct_id"]
+    B["👤 lead_qualified\nfull_name · phone"]
+    C["🏠 shipping_info_collected\nshipping_address · shipping_city"]
+    D["✅ user_confirmed\nuser_confirmation\n⚡ gate: requiere los 4 anteriores"]
+    E["💳 payment_confirmed\npayment_confirmation\n⚡ gate: requiere user_confirmed + phone + addr"]
+    F(["🤝 auto-escalate → human_handoff"])
+
+    A --> B --> C --> D --> E --> F
+```
+
+Cada checkpoint del DAG representa **suficiencia de información**, no una acción del bot. La diferencia es importante: "el bot dijo X" no es lo mismo que "el sistema sabe X". El DAG opera sobre lo segundo.
+
+**Los DAG gates** son la innovación operacional que distingue este sistema de los DAGs académicos (PPDPP, ChatSOP). Cuando el LLM propone un slot prematuramente — por ejemplo, marcar `user_confirmation=true` antes de tener dirección — el gate lo rechaza, registra un warning, pero **la respuesta del LLM al usuario igual se envía**. La conversación nunca se rompe; solo no se persiste el dato prematuro. Esa propiedad de fail-safe es lo que vuelve confiable el sistema.
+
+---
+
+## El patrón de dos llamadas
+
+Cada turno conversacional consta de exactamente 2 HTTP calls de n8n al backend, con 1 llamada al LLM en medio:
+
+```mermaid
+sequenceDiagram
+    participant W as WhatsApp
+    participant N as n8n
+    participant B as Backend FastAPI
+    participant L as LLM (gpt-4o-mini)
+    participant DB as PostgreSQL
+
+    W->>N: Webhook Chakra HQ · mensaje del cliente
+
+    N->>B: POST /api/v1/ingest/message
+    B->>DB: Validar client · idempotencia · bloqueo
+    B->>DB: Upsert client_user · find/create conversación (24h)
+    B->>DB: Advisory lock por conversation_id · persistir inbound
+    Note over B: Debounce 5s — espera ráfagas
+    B->>B: GoalStrategyEngine → directive
+    B->>DB: Bump strategy_version · persistir snapshot
+    B-->>N: directive · strategy_version · business_context · recent_messages
+
+    N->>L: system prompt + directive + historial (1 sola llamada, sin tools)
+    L-->>N: response_text + extracted_data
+
+    N->>B: POST /api/v1/agent/action
+    B->>B: Verificar strategy_version (409 si stale)
+    B->>B: DAG gates → merge extracted_data
+    B->>DB: Sync stable facts → client_users.profile
+    B->>DB: Auto-escalate si all_complete · persistir outbound + audit_log
+    B-->>N: approved · final_response_text · side_effects
+
+    N->>W: final_response_text via Chakra HQ
+```
+
+**Sin loops, sin tool-calling, sin rama dinámica del LLM.** El backend sabe todo lo que el LLM necesita saber antes de la llamada, y valida todo lo que el LLM produce después de la llamada.
+
+---
+
+## Estado de información en tres niveles
+
+Una conversación tiene tres tipos de información distintos, cada uno con su lugar:
+
+| Tipo | Descripción | Dónde vive | Persistencia |
+|------|-------------|------------|--------------|
+| **Datos del cliente** | Nombre, dirección, teléfono, preferencias | `client_users.profile` (JSONB) | Multi-conversación (siempre) |
+| **Estado de venta** | Producto elegido, cantidad, confirmaciones | `conversations.extracted_context` (JSONB) | Intra-conversación (24h) |
+| **Contexto efímero** | Inferencias del último turno | Transitorio en memoria del LLM | Por turno |
+
+> **Limitación conocida**: si un cliente abandona la venta a mitad del flujo y vuelve días después, el estado de venta se pierde porque vive en `extracted_context` de la conversación expirada. El perfil persiste pero el carrito no. Resolverlo requiere una entidad nueva (`purchase_intents`) — pendiente en roadmap.
+
+---
+
+## Multi-tenancy
+
+Cada tabla tenant-facing tiene `client_id UUID NOT NULL FK` que apunta a `clients`. Toda query filtra por `client_id`. La separación entre tenants es por convención en la capa de servicio — **no por Row-Level Security de Postgres**. Un bug en una query que olvide el filtro puede leer datos cross-tenant.
+
+Esto es deuda técnica reconocida que se va a tomar al tercer cliente productivo. Para MVP con un cliente demo, está dentro del riesgo aceptado.
+
+**Customización por cliente** vive en `clients.business_rules` (JSONB):
+- `default_goal`: qué goal del DAG se activa por defecto
+- `skip_lead_qualification`: omite checkpoint
+- `require_id_number`: agrega campo requerido
+- `currency`, `shipping_cities`, `shipping_rules`, `payment_methods`, `discount_rules`
+- `agent_persona`: nombre del agente, rol
+
+El `system_prompt_template` también es por cliente — cada negocio tiene su propia voz, persona y reglas de tono.
+
+---
+
+## Concurrencia y consistencia
+
+**Problema**: WhatsApp manda ráfagas. Un cliente que escribe "hola" + "quiero comprar" + "café molido" en 3 segundos genera 3 webhooks paralelos. Si los procesamos concurrentemente, el LLM puede ver contextos inconsistentes.
+
+**Soluciones aplicadas**:
+
+1. **Advisory lock** por `conversation_id`: `pg_advisory_xact_lock(hash(conv_id))` serializa los mensajes de la misma conversación dentro de la transacción. Se libera automáticamente con commit/rollback.
+2. **Debounce de 5 segundos**: tras commitear el primer mensaje, el backend espera 5s y verifica si llegó otro. Si sí, este turno no responde — deja que el siguiente mensaje (que ahora ve los anteriores) genere la respuesta.
+3. **Idempotencia por `chakra_message_id`**: webhook que llega dos veces con el mismo ID se reconoce como duplicado.
+4. **strategy_version**: protege contra que `/agent/action` opere sobre contexto que cambió entre las dos llamadas (ver ADR-003).
+
+> **Limitación conocida**: el `asyncio.sleep(5)` durante la transacción mantiene el connection pool ocupado. Bajo carga sostenida puede saturar el pool. Es deuda técnica priorizada.
+
+---
+
+## Filosofía de diseño
+
+Tres principios que se aplican consistentemente:
+
+1. **Fail-safe sobre fail-fast en la conversación.** Si una validación rechaza un slot del LLM, la respuesta al usuario igual se envía. La experiencia del cliente final no se interrumpe nunca por una decisión interna del backend.
+
+2. **Schema-first, then code.** Cada cambio significativo empieza por entender qué datos cambian, en qué tabla, con qué constraints. El código viene después. El `CLAUDE.md` y los ADRs reflejan esta práctica: el diseño se piensa antes de implementarse.
+
+3. **Determinístico donde se puede, probabilístico donde tiene que ser.** Lo que el negocio necesita controlar (orden, validación, persistencia) vive en código testeable. Lo que el cliente final percibe (tono, naturalidad) vive en el prompt y el modelo. La frontera es deliberada.

--- a/sales-ai-docs/docs/decisions/ADR-001-dag-over-search.md
+++ b/sales-ai-docs/docs/decisions/ADR-001-dag-over-search.md
@@ -1,0 +1,52 @@
+# ADR-001 — DAG sobre algoritmos de búsqueda
+
+- **Estatus**: Accepted
+- **Fecha**: 2026-04-03
+- **Decididores**: Sebastian + cofounder/principal architect
+
+## Contexto
+
+Al diseñar el motor que decide el siguiente movimiento del bot, evaluamos enfoques basados en literatura académica reciente sobre diálogo orientado a objetivos:
+
+- **PPDPP** (ICLR 2024): refuerzo + LLM para política de diálogo
+- **ChatSOP** (ACL 2025): planeación con MCTS sobre estados de diálogo
+- **GDP-Zero**: búsqueda Monte Carlo guiada por LLM para diálogos persuasivos
+
+Estos enfoques producen mejor comportamiento conversacional en benchmarks (27–91% mejora en controllability sobre LLM puro), pero a un costo: ChatSOP reporta ~8-9× más tokens consumidos por turno, dado que cada nodo del árbol de búsqueda implica una o varias llamadas al LLM para evaluar el estado.
+
+Para nuestro caso de uso (WhatsApp con clientes finales en LATAM, alta sensibilidad a costo y latencia, dominio comercial relativamente acotado), ese trade-off no compensa.
+
+## Decisión
+
+Usar un **DAG de checkpoints determinístico** como motor de política, con el LLM limitado a NLU/NLG. La estrategia se computa en código Python puro: dado el estado de información recolectada, el motor calcula qué checkpoint está completo, cuál está bloqueado, y cuál es el siguiente accionable. Sin búsqueda, sin árboles, sin llamadas adicionales al LLM para razonar sobre el estado.
+
+## Alternativas consideradas
+
+- **MCTS sobre estados de diálogo (ChatSOP-style)**: descartado por costo de tokens (~8-9× más por turno) y latencia. Para WhatsApp con turnos de varios segundos, agregar 2-3 segundos extra por turno degrada la experiencia notablemente.
+- **Refuerzo/PPDPP-style**: descartado por requerir dataset histórico de conversaciones etiquetadas con outcome — no lo tenemos. Y para entrenarlo necesitaríamos primero operar en producción durante meses con un sistema más simple.
+- **Slot filling tradicional (Rasa NLU/Dialogflow)**: descartado por fragilidad lingüística. La variedad de cómo un cliente colombiano pide café por WhatsApp es alta; las gramáticas tradicionales sobre-rechazan.
+- **Agente ReAct con tools**: descartado por costo (5-15 LLM calls por turno) y debugabilidad. Ver ADR-002.
+
+## Consecuencias
+
+### Positivas
+- Costo predecible: 1 LLM call por mensaje entrante, independiente de complejidad del DAG.
+- Latencia predecible: el cómputo del DAG es microsegundos.
+- Auditabilidad: cada decisión es código Python con tests unitarios. No hay caja negra.
+- Customizable por cliente: `business_rules` JSONB permite modificar el DAG (skip checkpoints, agregar campos requeridos) sin código.
+- El LLM se vuelve la pieza más reemplazable del sistema. Si sale un modelo mejor o más barato, se cambia el string del modelo.
+
+### Negativas
+- Cada nuevo "goal" (ej. servicio post-venta, soporte técnico) requiere escribir un nuevo `_build_*_checkpoints`. No es plug-and-play como un agente con tools.
+- El sistema es bueno en el dominio para el que fue diseñado (venta) y mediocre fuera de él. No es un asistente general.
+- Los DAG estáticos no aprenden del comportamiento real del cliente. Si descubrimos que el orden óptimo de pedir datos es distinto, hay que cambiar código, no parámetros.
+
+### Trade-offs explícitos
+- Ganamos confiabilidad y costo a cambio de flexibilidad. Para una startup en validación de producto con un dominio claro, esto es correcto.
+
+## Cuándo revisar
+
+Revisar esta decisión si:
+- El dominio se vuelve mucho más amplio (10+ tipos de conversación distintos por cliente)
+- Aparece evidencia de que el orden de checkpoints óptimo varía significativamente entre segmentos de clientes
+- El costo de tokens deja de ser una restricción material (muy improbable en el horizonte cercano)

--- a/sales-ai-docs/docs/decisions/ADR-002-no-tools-pattern.md
+++ b/sales-ai-docs/docs/decisions/ADR-002-no-tools-pattern.md
@@ -1,0 +1,55 @@
+# ADR-002 — Patrón de dos llamadas sin tools
+
+- **Estatus**: Accepted
+- **Fecha**: 2026-04-03
+- **Decididores**: Sebastian + cofounder/principal architect
+
+## Contexto
+
+La arquitectura típica de un "agente" LLM moderno (LangChain, OpenAI Assistants, AutoGPT) le da al modelo un set de herramientas (tools/functions) que puede llamar en un loop: el modelo decide qué tool usar, observa el resultado, decide la siguiente, hasta que cree haber terminado el objetivo del usuario.
+
+Este patrón funciona bien para tareas open-ended donde el espacio de acciones es grande y el objetivo es ambiguo (asistente personal, agente de investigación). Para nuestro caso — venta por WhatsApp con flujo conocido y reglas estrictas — introduce más problemas que soluciones:
+
+- Costo variable e impredecible: 5-15 llamadas LLM por turno son comunes.
+- Latencia acumulativa: cada iteración suma 1-3 segundos.
+- Debugabilidad pobre: si el agente toma una mala decisión, hay que reconstruir la cadena de razonamiento.
+- Inseguridad: el modelo puede llamar tools en órdenes inesperados, encadenar acciones que vistas individualmente son válidas pero combinadas son destructivas.
+- Las CRUD APIs no son buenas interfaces para LLMs — los endpoints típicos del backend exponen demasiada superficie y demasiado bajo nivel.
+
+## Decisión
+
+Eliminar el concepto de "tools" del agente. Cada turno conversacional consiste en:
+
+1. **n8n → POST /api/v1/ingest/message** (backend prepara contexto + directiva)
+2. **n8n → LLM** (una sola llamada, sin function calling)
+3. **n8n → POST /api/v1/agent/action** (backend valida y persiste lo que el LLM extrajo)
+
+El backend sabe todo lo que el LLM necesita saber antes de la llamada. El LLM no descubre nada que el backend no le haya dicho. El backend valida todo lo que el LLM propone después de la llamada.
+
+## Alternativas consideradas
+
+- **Tools restringidos (3-5 funciones acotadas)**: menor superficie que un agente abierto, pero sigue introduciendo loops y costo variable. Descartado por la misma razón general.
+- **OpenAI Assistants API con function calling**: lock-in con OpenAI, costo por threads persistentes, complejidad operacional alta. Descartado.
+- **Function calling solo para extracción estructurada**: aquí hay un punto válido — usar `response_format` o function calling como mecanismo de structured output (no como agente de acciones). Esto sí lo vamos a adoptar pero como técnica de output, no como patrón de agente. Pendiente de ADR cuando se implemente.
+
+## Consecuencias
+
+### Positivas
+- Costo y latencia constantes por turno. Capacidad de planeación lineal.
+- El sistema es debuggeable: 2 HTTP calls + 1 LLM call, todas inspeccionables.
+- El backend mantiene control total sobre qué se persiste, en qué orden, con qué validaciones. El LLM nunca toca la DB directamente.
+- Fail-safe: si el backend rechaza la propuesta del LLM, el texto de respuesta igual va al usuario. La conversación no se rompe.
+
+### Negativas
+- Si un cliente requiere comportamiento que necesita ramificación condicional dinámica (consultar API externa para decidir flujo), hay que modelarlo en el backend, no delegarlo al LLM.
+- No aprovechamos las capacidades nativas de tool-calling de modelos modernos (parallel function calling, etc.). Si el ecosistema evoluciona en esa dirección y los modelos se vuelven mucho mejores con tools, podríamos quedarnos atrás.
+
+### Trade-offs explícitos
+- Ganamos confiabilidad operacional a cambio de capacidad emergente. Para venta repetible, vale la pena. Para soporte técnico complejo, posiblemente no.
+
+## Cuándo revisar
+
+Revisar esta decisión si:
+- Aparece un caso de uso (mismo dominio o adyacente) donde el flujo no es modelable como DAG — requiere razonamiento dinámico no anticipable
+- Los modelos LLM se vuelven dramáticamente mejores en tool-use con costo competitivo a una sola llamada
+- Encontramos que el patrón nos limita en una dirección de producto importante

--- a/sales-ai-docs/docs/decisions/ADR-003-strategy-version.md
+++ b/sales-ai-docs/docs/decisions/ADR-003-strategy-version.md
@@ -1,0 +1,52 @@
+# ADR-003 — strategy_version contra contexto viejo
+
+- **Estatus**: Accepted
+- **Fecha**: 2026-04-10
+- **Decididores**: Sebastian + cofounder/principal architect
+
+## Contexto
+
+El patrón de dos llamadas (ADR-002) introduce una ventana entre `/ingest/message` (donde el backend computa la directiva) y `/agent/action` (donde el backend valida la propuesta del LLM). Entre esas dos llamadas pueden pasar varios segundos — el tiempo de la llamada al LLM más la latencia de red de n8n.
+
+En esa ventana pueden ocurrir varias cosas que invalidan la decisión del LLM:
+- Otro mensaje del usuario llega y se procesa (el cliente escribió dos veces seguidas)
+- n8n hace retry de la primera llamada y se procesan dos veces el mismo mensaje
+- Un operador humano modifica el estado de la conversación desde otro canal (futuro)
+- Un job batch toca la conversación
+
+Si el LLM propone "marcar `user_confirmation=true`" basándose en un contexto donde faltaba la dirección, pero en el momento de validar ya llegó la dirección, la decisión es válida — pero también puede ser al revés: el LLM extrajo basándose en un estado que ya cambió y la propuesta es incorrecta.
+
+La revisión arquitectónica de inicios de abril (`revision_par_backend_n8n_dag.md`) marcó esto como riesgo alto.
+
+## Decisión
+
+Introducir un campo `strategy_version` en `conversations` que se incrementa atómicamente en cada `/ingest/message`. El backend devuelve ese número en la respuesta del ingest, y exige que `/agent/action` lo eche de regreso. Si la versión que llega en `/agent/action` no coincide con la versión actual de la conversación en DB, el backend responde **HTTP 409 Conflict** con `error: stale_context`. n8n debe entonces re-llamar a `/ingest/message` con el mismo mensaje original para regenerar la directiva.
+
+## Alternativas consideradas
+
+- **No hacer nada**: aceptar que algunas propuestas se ejecutarán sobre contexto viejo. Descartado — los DAG gates mitigan parte del problema pero no todo, y la falta de mecanismo explícito hace muy difícil debuggear casos que sí se cuelan.
+- **Lock optimista por hash de extracted_context**: más caro de calcular y más frágil ante cambios de orden de campos en JSONB. Descartado por costo.
+- **Lock pesimista durante toda la ventana del LLM**: bloquearía otras requests del mismo usuario, mata throughput. Descartado.
+- **Timestamp-based**: usar `last_message_at` como token. Descartado por riesgo de colisión de timestamps en ráfagas (resolución de microsegundos no es siempre garantía suficiente bajo carga).
+
+## Consecuencias
+
+### Positivas
+- Detección determinística de contexto viejo. Si el `/agent/action` opera sobre estado obsoleto, el backend lo rechaza explícitamente.
+- Auditable: el `strategy_version` queda en logs y permite reconstruir qué versión vio el LLM.
+- Simple: un solo entero, una comparación, un código de error específico.
+- Compatible con retries: n8n puede hacer retry de ingest sin riesgo de duplicar efectos secundarios (la idempotencia de `chakra_message_id` cubre eso).
+
+### Negativas
+- n8n debe manejar el 409 explícitamente — agrega complejidad al workflow.
+- Si la lógica de retry de n8n no está bien armada, el sistema puede quedarse en loop pidiendo nueva directiva. Mitigación: límite de retries en n8n.
+- El `strategy_version` no se versiona históricamente (sólo el actual). Si quisiéramos reconstruir directivas pasadas, hay que mirar `messages.created_at` correlacionado con `audit_log`. Suficiente por ahora.
+
+### Trade-offs explícitos
+- Agregamos una columna y una verificación a cambio de garantía de consistencia. El costo es mínimo, el beneficio es grande.
+
+## Cuándo revisar
+
+Revisar esta decisión si:
+- Aparecen patrones de uso donde el `strategy_version` se vuelve un cuello de botella (improbable, es solo un entero)
+- Se necesita reconstruir histórico de directivas para analytics avanzado — entonces `strategy_snapshot` JSONB en `conversations` puede no bastar y haya que considerar tabla de history

--- a/sales-ai-docs/docs/decisions/ADR-004-drop-leads-orders.md
+++ b/sales-ai-docs/docs/decisions/ADR-004-drop-leads-orders.md
@@ -1,0 +1,55 @@
+# ADR-004 — Drop de leads, orders, order_line_items
+
+- **Estatus**: Accepted
+- **Fecha**: 2026-04-21
+- **Decididores**: Sebastian + cofounder/principal architect
+
+## Contexto
+
+El schema inicial (migración 001) incluía tres tablas para modelar el ciclo de vida comercial:
+
+- `leads` — oportunidades de venta con estado `new → contacted → qualified → proposal_sent → won/lost`
+- `orders` — pedidos con estado `draft → confirmed → processing → shipped → delivered/cancelled`
+- `order_line_items` — items de pedido con `unit_price` snapshot del catálogo
+
+El diseño asumía que el agente, al detectar intención de compra, crearía un lead, lo iría enriqueciendo, y eventualmente materializaría un order con line items. La arquitectura tenía action handlers (`create_lead`, `propose_order`, `confirm_order`, `cancel_order`) que el agente proponía y el backend validaba.
+
+Tras el refactor del 19 de abril (que también colapsó la state machine — ver ADR-007), el sistema dejó de usar action handlers. El flujo real era:
+- El cliente expresa intención → todo se acumula en `conversations.extracted_context` como JSONB
+- Cuando todo está completo → auto-escalate a `human_handoff`
+- Un humano cierra la venta manualmente fuera del sistema (toma el comprobante de pago, coordina envío)
+
+Auditando la DB (mediados de abril): las tres tablas estaban con 0 filas. Ningún code path las poblaba después del refactor. Mantenerlas en el schema activo era confuso (sugería que existía una capa de "órdenes formales" que no existía) y genera deuda mental al razonar sobre el sistema.
+
+## Decisión
+
+Dropear las tres tablas (`leads`, `orders`, `order_line_items`) y todas las columnas relacionadas en `conversations` (`lead_id`, `order_id`, etc.) en la migración 007. El estado de la venta vive enteramente en `conversations.extracted_context` (JSONB) durante la conversación activa, y el cierre se hace fuera del sistema por un humano.
+
+## Alternativas consideradas
+
+- **Mantener las tablas vacías "por si acaso"**: descartado. Schema activo debe reflejar la realidad. Cargar peso muerto solo confunde.
+- **Mantener las tablas y empezar a poblarlas**: requería reintroducir action handlers, validación de stock, gestión de estados de orden, etc. — todo trabajo grande para un valor marginal en MVP. Descartado por priorización.
+- **Mover a una migración futura**: descartado. Si la deuda existe, quitarla pronto evita que código nuevo siga asumiendo que existen.
+
+## Consecuencias
+
+### Positivas
+- Schema activo refleja la realidad del sistema. Razonar sobre el modelo es más simple.
+- Menos chance de que código nuevo (incluyendo Claude Code) referencie tablas inexistentes asumiendo que están vivas.
+- La migración 007 también dropeó columnas mirror que estaban siempre nulas (`whatsapp_id`, `email`, `full_name`, etc. en `client_users`) — agregando coherencia.
+
+### Negativas
+- **Pérdida del modelo de venta como entidad de negocio.** Reportes de "cuántas ventas cerradas el mes pasado" requieren parsear JSONB de `conversations` o consultar `client_users.profile.purchases`. Es viable pero menos elegante que un `SELECT COUNT(*) FROM orders WHERE status = 'confirmed'`.
+- **Pérdida de continuidad entre conversaciones.** Si una conversación expira por la ventana de 24h y el cliente vuelve después, el estado de la venta se pierde porque vivía en `extracted_context` de la conversación vieja. Esto produce el bug del re-saludo y la pérdida de contexto de venta entre sesiones. (Detectado como problema en discusión de roadmap del 25 de abril.)
+- Si en el futuro queremos materialización formal de órdenes (para pagar APIs de envío, integrar pasarelas, etc.), habrá que reintroducir entidades.
+
+### Trade-offs explícitos
+- Ganamos simplicidad y velocidad de iteración a cambio de poder de modelado. Para MVP sin volumen, vale la pena. Para producción con varios clientes, va a ser necesario reintroducir alguna forma de entidad de venta.
+
+## Cuándo revisar
+
+**Esta decisión está pidiendo revisión activamente.** El bug de pérdida de contexto entre conversaciones (carrito abandonado se pierde) ya está afectando UX. La solución probable es reintroducir una tabla nueva con propósito más claro (`purchase_intents`), no resucitar `leads`/`orders`. Cuando eso pase, este ADR queda como contexto histórico (no superseded — la decisión de dropear esas tablas específicas sigue válida) y se escribe ADR-008 para `purchase_intents`.
+
+Revisar también si:
+- Aterrizamos un cliente con volumen donde reportes sobre JSONB se vuelven lentos (improbable a corto plazo, JSONB con índices funciona bien hasta cientos de miles de filas)
+- Se necesita integrar pasarela de pago o API de envíos automatizada (eso requiere entidades formales de orden)

--- a/sales-ai-docs/docs/decisions/ADR-005-persistent-profile.md
+++ b/sales-ai-docs/docs/decisions/ADR-005-persistent-profile.md
@@ -1,0 +1,67 @@
+# ADR-005 — Perfil persistente en client_users
+
+- **Estatus**: Accepted
+- **Fecha**: 2026-04-21
+- **Decididores**: Sebastian + cofounder/principal architect
+
+## Contexto
+
+Antes de la migración 007, los datos del cliente final vivían en dos lugares:
+
+- Columnas mirror en `client_users` (`full_name`, `email`, `address`, `city`, `identification_number`, `whatsapp_id`, `metadata`) — pensadas para almacenar datos persistentes
+- `conversations.extracted_context` (JSONB) — usado en la práctica para todo
+
+Auditando la DB: las columnas mirror estaban siempre nulas. El código nunca las llenaba después del refactor del 19 de abril. Toda la información del cliente se acumulaba en `extracted_context`, lo que significa que se perdía al expirar la conversación (ventana de 24h o reset por idle de 30 min).
+
+Síntoma visible: un cliente que vuelve después de varios días es tratado como nuevo. El bot le pregunta nombre, ciudad, dirección — datos que el sistema ya tenía pero no pudo recuperar.
+
+## Decisión
+
+Eliminar las columnas mirror de `client_users` y reemplazarlas con una sola columna `profile JSONB NOT NULL DEFAULT '{}'::jsonb`. Esta columna almacena datos persistentes del cliente entre conversaciones:
+
+```json
+{
+  "first_name": "Juan",
+  "full_name": "Juan Pérez",
+  "email": "...",
+  "city": "Manizales",
+  "shipping_address": "Calle 10 #5-20",
+  "preferences": {"grind": "molido", "roast": "medio"},
+  "purchase_count": 2,
+  "purchases": [{"date": "...", "product_id": "...", "total": 80000}],
+  "last_conversation_summary": "..."
+}
+```
+
+Lógica de sincronización:
+- En `agent_action.py`, cuando se aceptan slots estables (full_name, phone, shipping_address, shipping_city, email), se mergean a `profile` además de a `extracted_context`.
+- En `ingest.py`, cuando se crea una conversación nueva, se hace seed del `extracted_context` desde el `profile` para que el LLM arranque sabiendo lo que tenemos en archivo.
+
+## Alternativas consideradas
+
+- **Mantener columnas tipadas**: más estricto en schema, pero requiere migración cada vez que aparece un campo nuevo (preferencias, historial de compras, etc.). Descartado por velocidad de iteración.
+- **Tabla separada `client_user_profiles`** con relación 1:1: técnicamente más limpia pero overkill para la cantidad de datos. Una sola fila por usuario, JOINs adicionales en cada query. Descartado.
+- **Solo `extracted_context`, sin perfil**: descartado — es el problema actual que se quiere resolver.
+
+## Consecuencias
+
+### Positivas
+- Cliente recurrente es reconocido entre conversaciones. El system prompt del LLM puede saludar diferente si el cliente ya compró antes.
+- Schema flexible para agregar campos sin migraciones (preferencias nuevas, segmentación, etc.).
+- El bug del re-saludo en el primer mensaje de una nueva conversación queda parcialmente resuelto (el LLM recibe el contexto, aunque la regla del prompt sigue siendo importante).
+- Capacidad emergente: `purchase_count` y `purchases` permiten lógica de remarketing y recompra.
+
+### Negativas
+- Schema flexible = sin garantías de tipos. Un campo mal escrito (typo en `frist_name`) no falla; simplemente no se usa. Mitigación: validación en código + helper de seed/merge centralizado.
+- Datos sensibles (PII) en JSONB son menos auditables que en columnas. No hay forma trivial de hacer "encripta solo la columna `phone`" si llegáramos a necesitarlo. Mitigación pendiente: si encriptación a nivel campo se vuelve requirement, considerar mover esos campos a columnas tipadas.
+- **NO resuelve el caso de venta interrumpida.** El `profile` guarda datos del cliente, no estado de venta en curso. Si un cliente estaba a punto de comprar 3 bolsas y vuelve después, el `profile` sabe quién es pero no que estaba comprando. Eso requiere otra entidad — pendiente de ADR-008 (`purchase_intents`).
+
+### Trade-offs explícitos
+- Aceptamos schema laxo a cambio de iteración rápida. Estamos en MVP; la rigidez correcta es la que sirve hoy, no la que servirá en 2 años.
+
+## Cuándo revisar
+
+Revisar esta decisión si:
+- La cantidad de campos del perfil crece a 20+ y se vuelve confuso navegarlos como JSONB
+- Aparecen requirements de compliance (encriptación a nivel campo, retention policies por tipo de dato)
+- El segundo cliente en producción tiene shape de perfil radicalmente distinta y forzar `business_rules` para customizar deja de ser razonable

--- a/sales-ai-docs/docs/decisions/ADR-006-varchar-check-over-enums.md
+++ b/sales-ai-docs/docs/decisions/ADR-006-varchar-check-over-enums.md
@@ -1,0 +1,50 @@
+# ADR-006 — VARCHAR + CHECK sobre ENUMs nativos
+
+- **Estatus**: Accepted
+- **Fecha**: 2026-04-03
+- **Decididores**: Sebastian + cofounder/principal architect
+
+## Contexto
+
+PostgreSQL ofrece dos formas de modelar columnas con conjunto fijo de valores válidos:
+
+1. **ENUM nativo**: `CREATE TYPE conversation_state AS ENUM ('active', 'human_handoff', 'closed')`. Type-safe a nivel DB.
+2. **VARCHAR + CHECK constraint**: `state VARCHAR(30) CHECK (state IN ('active', 'human_handoff', 'closed'))`.
+
+Para un sistema en evolución activa donde los conjuntos de valores cambian (hemos colapsado 7 estados a 3 — ver ADR-007), la operación de modificar el set importa.
+
+Con ENUMs nativos, agregar un valor requiere `ALTER TYPE ... ADD VALUE`. Eliminar valores es prácticamente imposible sin renombrar el tipo, migrar datos, eliminar el tipo viejo. Cualquier cambio bloquea operaciones sobre las tablas que usan el tipo durante la migración.
+
+Con VARCHAR + CHECK, modificar el set es `DROP CONSTRAINT` + `ADD CONSTRAINT` — operaciones rápidas, sin lock prolongado.
+
+## Decisión
+
+Usar `VARCHAR + CHECK CONSTRAINT` para todas las columnas con conjunto fijo de valores: `conversations.state`, `messages.direction`, etc.
+
+## Alternativas consideradas
+
+- **ENUMs nativos**: descartado por costo de migraciones futuras.
+- **TEXT sin constraint, validación solo en aplicación**: descartado — perdemos la garantía a nivel DB. Un bug en el ORM que escribe "invalid_state" no se detecta hasta que alguien lee.
+- **Tabla de lookup separada con FK**: overkill para sets pequeños y estables como estados. Reservado para sets grandes/dinámicos (ej. catálogo de productos) donde tiene sentido.
+
+## Consecuencias
+
+### Positivas
+- Migraciones de schema sin downtime al modificar conjuntos válidos.
+- Misma garantía de integridad que ENUMs (ningún valor inválido entra a DB).
+- Compatible directo con SQLAlchemy `String(30)` — no requiere mapeo especial de tipos.
+
+### Negativas
+- Performance: comparaciones de string son marginalmente más lentas que de enum (negligible en práctica).
+- Storage: VARCHAR(30) ocupa más bytes que un ENUM (4 bytes). Para tablas con millones de filas podría sumar — irrelevante a nuestra escala.
+- Menos auto-documentación: un `\d+ conversations` en psql muestra el constraint, pero no es tan visualmente prominente como un tipo ENUM.
+
+### Trade-offs explícitos
+- Ganamos flexibilidad operacional a un costo de performance/storage marginal.
+
+## Cuándo revisar
+
+Revisar esta decisión si:
+- Llegamos a tablas de >100M filas donde el storage extra es material (improbable en horizonte cercano)
+- Aparecen requirements de tipo-strictness fuerte (compliance, validación cross-DB)
+- El conjunto de valores se estabiliza y deja de cambiar — entonces ENUMs serían marginalmente mejores pero la migración inicial cuesta más que el beneficio

--- a/sales-ai-docs/docs/decisions/ADR-007-state-machine-collapse.md
+++ b/sales-ai-docs/docs/decisions/ADR-007-state-machine-collapse.md
@@ -1,0 +1,92 @@
+# ADR-007 — Colapso de state machine de 7 a 3 estados
+
+- **Estatus**: Accepted
+- **Fecha**: 2026-04-19
+- **Decididores**: Sebastian + cofounder/principal architect
+
+## Contexto
+
+El diseño original (migración 001) modelaba la conversación con 7 estados:
+
+```mermaid
+stateDiagram-v2
+    [*] --> idle
+    idle --> active
+    active --> qualifying
+    active --> selling
+    active --> human_handoff
+    active --> closed
+    qualifying --> selling
+    qualifying --> active
+    qualifying --> human_handoff
+    qualifying --> closed
+    selling --> ordering
+    selling --> qualifying
+    selling --> active
+    selling --> human_handoff
+    selling --> closed
+    ordering --> selling
+    ordering --> human_handoff
+    ordering --> closed
+    human_handoff --> active
+    human_handoff --> closed
+    closed --> [*]
+```
+
+Cada estado tenía un set de acciones válidas distintas (`greet`, `classify_intent`, `ask_question`, `search_products`, `propose_order`, `confirm_order`, `escalate`, etc.) que el agente podía proponer y el backend validaba.
+
+La intención era restringir lo que el LLM podía hacer en cada fase: no se permite `propose_order` mientras la conversación esté en `qualifying`, no se permite `confirm_order` mientras esté en `ordering` sin datos completos, etc.
+
+Auditando los datos al 19 de abril:
+- Ninguna conversación había transicionado fuera de `active` o `human_handoff`. El sistema usaba en producción sólo 3 de los 7 estados.
+- Las transiciones entre estados internos (`qualifying → selling → ordering`) nunca se disparaban porque ya no existían action handlers que las propusieran.
+- La validación de "qué acción es válida en qué estado" era código muerto — el agente no proponía acciones (ver ADR-002 sobre eliminación de tools).
+
+Mantener 7 estados con sus tablas de transiciones, validaciones, y código asociado era complejidad sin valor.
+
+## Decisión
+
+Colapsar la state machine a 3 estados:
+
+```mermaid
+stateDiagram-v2
+    [*] --> active
+    active --> human_handoff : DAG completo (auto-escalate)
+    active --> closed
+    human_handoff --> active : operador interviene
+    human_handoff --> closed
+    closed --> [*]
+```
+
+- **active**: conversación normal, bot responde
+- **human_handoff**: escalada a operador humano, bot ya no responde
+- **closed**: terminada, terminal
+
+La progresión del flujo de venta (qualifying, selling, ordering) ya no se modela como estado conversacional sino como **progreso del DAG** (`progress_pct`, `current_checkpoint` en `conversations`). Esa es información estratégica, no estado del diálogo.
+
+## Alternativas consideradas
+
+- **Mantener 7 estados pero documentarlos como aspiracionales**: descartado. Estado en DB que nunca se usa es trampa para Claude Code y para humanos nuevos.
+- **Colapsar a 4 estados (agregar `paused`)**: descartado por YAGNI. Si en el futuro necesitamos `paused`, se agrega.
+- **Eliminar la state machine completa**: descartado. Necesitamos al menos `active vs human_handoff vs closed` para que n8n y el front sepan si el bot debe responder.
+
+## Consecuencias
+
+### Positivas
+- State machine refleja el comportamiento real. Razonar sobre el sistema es más simple.
+- Menos código que mantener (las funciones `validate_action`, los action handlers, las transiciones entre estados internos) — todo eliminado en el refactor.
+- La distinción "fase del diálogo" vs "progreso de venta" queda explícita: lo primero es el estado, lo segundo es el DAG. Cada uno responde a una pregunta distinta.
+
+### Negativas
+- Si un cliente futuro necesita comportamientos diferenciados por fase (ej. tono distinto en qualifying vs selling), no podemos hacerlo a nivel de state machine — habría que modelarlo dentro del prompt o como overrides de `business_rules`.
+- Perdimos la capacidad de "auto-pausar" una conversación en estados intermedios. Si quisiéramos pausar mientras esperamos confirmación humana de un dato puntual sin escalar completo, no hay estado para eso.
+
+### Trade-offs explícitos
+- Aceptamos menos expresividad del state machine a cambio de coherencia con la realidad. Si la expresividad vuelve a hacer falta, se reintroduce con justificación específica.
+
+## Cuándo revisar
+
+Revisar esta decisión si:
+- Aparece un caso de uso real donde necesitamos diferenciar "el bot está esperando algo específico" de simplemente "active"
+- Un cliente requiere flujos donde el bot responde diferente según una fase intermedia que hoy no modelamos
+- El front de operador necesita mostrar "en qué fase está cada conversación" — podríamos derivarlo del DAG progress, pero si necesitamos un eje distinto, este ADR se revisa

--- a/sales-ai-docs/docs/decisions/README.md
+++ b/sales-ai-docs/docs/decisions/README.md
@@ -1,0 +1,82 @@
+# Architecture Decision Records (ADRs)
+
+Registro append-only de decisiones arquitectónicas del proyecto. Cada ADR documenta una decisión tomada, su contexto, las alternativas consideradas, y sus consecuencias.
+
+## Reglas
+
+1. **Append-only**: una vez escrito y mergeado, un ADR no se modifica. Si la decisión cambia, se escribe un ADR nuevo que "supersede" al anterior.
+2. **Numeración secuencial**: `ADR-NNN-titulo-corto.md`, sin saltos.
+3. **Naming**: kebab-case, descriptivo pero corto (≤ 6 palabras).
+4. **Estatus posibles**: `Accepted` (vigente), `Superseded by ADR-NNN` (reemplazado), `Deprecated` (obsoleto sin reemplazo).
+5. **Fecha**: la del día en que se acepta la decisión, no la del día en que se documenta.
+
+## Cuándo escribir un ADR
+
+Test rápido: **¿alguien dentro de 6 meses preguntará "por qué hicimos esto así"?** Si la respuesta es sí, ADR.
+
+Casos típicos:
+- Adopción o abandono de una tecnología (librería, framework, paradigma)
+- Decisión de schema con consecuencias multi-tabla
+- Patrón de seguridad o auth
+- Drop de tabla, columna o feature significativa
+- Trade-off costo/latencia/complejidad explícitamente discutido
+- Decisión que va contra la convención por una razón específica
+
+Casos donde NO hace falta ADR:
+- Refactor menor sin cambio semántico
+- Bug fix
+- Ajuste de prompt
+- Cambio de copy en mensajes
+
+## Plantilla
+
+```markdown
+# ADR-NNN — Título corto en sentence case
+
+- **Estatus**: Accepted | Superseded by ADR-MMM | Deprecated
+- **Fecha**: YYYY-MM-DD
+- **Decididores**: nombres o roles
+
+## Contexto
+
+¿Qué problema estábamos resolviendo? ¿Qué fuerzas estaban en juego?
+Estado del sistema en ese momento, restricciones, tensiones técnicas o de negocio.
+
+## Decisión
+
+Qué decidimos hacer, en una o dos oraciones claras.
+
+## Alternativas consideradas
+
+- **Alternativa A**: descripción + por qué la descartamos
+- **Alternativa B**: descripción + por qué la descartamos
+- **Alternativa C**: ...
+
+## Consecuencias
+
+### Positivas
+- ...
+
+### Negativas
+- ...
+
+### Neutras o trade-offs explícitos
+- ...
+
+## Cuándo revisar
+
+Condición o métrica que dispararía revisar la decisión.
+Ej: "Cuando tengamos 3+ clientes con catálogo > 50 SKUs."
+```
+
+## Índice de ADRs
+
+| # | Título | Estatus | Fecha |
+|---|--------|---------|-------|
+| 001 | DAG sobre algoritmos de búsqueda | Accepted | 2026-04-03 |
+| 002 | Patrón de dos llamadas sin tools | Accepted | 2026-04-03 |
+| 003 | strategy_version contra contexto viejo | Accepted | 2026-04-10 |
+| 004 | Drop de leads, orders, order_line_items | Accepted | 2026-04-21 |
+| 005 | Perfil persistente en client_users | Accepted | 2026-04-21 |
+| 006 | VARCHAR + CHECK sobre ENUMs nativos | Accepted | 2026-04-03 |
+| 007 | Colapso de state machine de 7 a 3 estados | Accepted | 2026-04-19 |


### PR DESCRIPTION
…grams

Adds full documentation suite: architecture overview, glossary, 7 ADRs covering key decisions (DAG, two-call pattern, state machine collapse, persistent profile, etc.). All ASCII diagrams converted to Mermaid. Includes .gitignore for local CLAUDE.md and Python artifacts. Infrastructure hostnames replaced with placeholders for security.