### PR TITLE
docs: Mermaid en README, CLAUDE.md plain text, fix refs demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,67 +49,43 @@ Hace tres cosas que un backend de chatbot típico no hace:
 
 Cada mensaje entrante en WhatsApp genera **exactamente 2 llamadas HTTP** de n8n al backend y **1 llamada al LLM**. Sin tool-calling, sin loops.
 
-```
-┌─────────────────────────────────────────────────────────────────────┐
-│                         FLUJO POR MENSAJE                           │
-│                                                                     │
-│  WhatsApp ──► n8n ──► LLAMADA 1: POST /api/v1/ingest/message       │
-│                           │                                         │
-│                           │  Backend (1 transacción):               │
-│                           │   1. Validar cliente (tenant)           │
-│                           │   2. Verificar idempotencia             │
-│                           │   3. Upsert client_user                 │
-│                           │   4. Bloqueo de usuario                 │
-│                           │   5. Conversación (ventana 24h, reset   │
-│                           │      extracted_context si idle 30+min)  │
-│                           │   6. Advisory lock (concurrencia)       │
-│                           │   7. Persistir mensaje entrante         │
-│                           │   8. Debounce 5s (evita responder       │
-│                           │      cuando hay mensajes encolados)     │
-│                           │   9. Calcular directiva (DAG)           │
-│                           │  10. Persistir strategy_version + meta  │
-│                           │                                         │
-│                           ▼                                         │
-│                    Responde:                                        │
-│                    • strategy_directive (texto para el LLM)         │
-│                    • strategy_meta (goal, progress, checkpoint)     │
-│                    • strategy_version (número entero, clave)        │
-│                    • client_config (system_prompt, modelo, temp)    │
-│                    • user_context (display_name, flags has_*)       │
-│                    • product_catalog (con UUID + SKU + precio)      │
-│                    • business_context (bloque de reglas formateado) │
-│                    • conversation_summary (lo ya sabido)            │
-│                    • recent_messages (últimos 20)                   │
-│                           │                                         │
-│                           ▼                                         │
-│               n8n arma el system prompt y llama al LLM             │
-│               LLM devuelve: response_text + extracted_data          │
-│                           │                                         │
-│                           ▼                                         │
-│              LLAMADA 2: POST /api/v1/agent/action                  │
-│                           │                                         │
-│                           │  Backend:                               │
-│                           │   1. Verificar strategy_version         │
-│                           │      (si no coincide → 409)             │
-│                           │   2. Mergear extracted_data en          │
-│                           │      conversation.extracted_context,    │
-│                           │      aplicando DAG gates                │
-│                           │   3. Si todos los checkpoints listos    │
-│                           │      → auto-escalar a human_handoff     │
-│                           │   4. Aplicar proposed_transition (raro) │
-│                           │   5. Persistir mensaje saliente         │
-│                           │   6. Audit log                          │
-│                           │                                         │
-│                           ▼                                         │
-│                    Responde:                                        │
-│                    • approved, final_response_text                  │
-│                    • new_state                                      │
-│                    • side_effects (context_updated, escalated,      │
-│                      warning:premature_summary, …)                  │
-│                           │                                         │
-│                           ▼                                         │
-│               n8n envía final_response_text → WhatsApp             │
-└─────────────────────────────────────────────────────────────────────┘
+```mermaid
+sequenceDiagram
+    participant W as WhatsApp
+    participant N as n8n
+    participant B as Backend FastAPI
+    participant L as LLM (gpt-4o-mini)
+    participant DB as PostgreSQL
+
+    W->>N: Webhook Chakra HQ
+
+    rect rgb(240, 248, 255)
+    Note over N,DB: LLAMADA 1 — Ingesta
+    N->>B: POST /api/v1/ingest/message
+    B->>DB: 1. Validar tenant + idempotencia
+    B->>DB: 2. Upsert client_user + bloqueo
+    B->>DB: 3. Conversación (ventana 24h)
+    B->>DB: 4. Advisory lock + persistir inbound
+    Note over B: 5. Debounce 5s
+    B->>B: 6. GoalStrategyEngine → directive
+    B->>DB: 7. Bump strategy_version
+    B-->>N: strategy_directive + strategy_version + client_config<br/>user_context + product_catalog + business_context<br/>conversation_summary + recent_messages
+    end
+
+    N->>L: system prompt + directive + historial
+    L-->>N: response_text + extracted_data
+
+    rect rgb(255, 248, 240)
+    Note over N,DB: LLAMADA 2 — Validación
+    N->>B: POST /api/v1/agent/action
+    B->>B: 1. Verificar strategy_version (409 si stale)
+    B->>B: 2. DAG gates → merge extracted_data
+    B->>DB: 3. Auto-escalate si all_complete
+    B->>DB: 4. Persistir outbound + audit_log
+    B-->>N: approved + final_response_text + side_effects
+    end
+
+    N->>W: final_response_text via Chakra
 ```
 
 **Propiedad clave:** si el backend rechaza un dato (p. ej. `user_confirmation` sin teléfono), el texto que el LLM generó **igual se envía al usuario**. La conversación no se interrumpe — solo no se persiste el dato prematuro.
@@ -122,25 +98,15 @@ Función pura: `(goal, extracted_context, business_rules) → StrategyDirective`
 
 ### DAG actual del goal `close_sale`
 
-```
-product_matched ─────────┐
-   (product_id)          │
-        │                ▼
-        │          lead_qualified
-        │          (full_name, phone)
-        │                │
-        │                ▼
-        │         shipping_info_collected
-        │         (shipping_address, shipping_city)
-        │                │
-        └────────────────┤
-                         ▼
-                   user_confirmed
-                   (user_confirmation)
-                         │
-                         ▼
-                  payment_confirmed
-                  (payment_confirmation)
+```mermaid
+graph TD
+    A["📦 product_matched<br/>product_id"]
+    B["👤 lead_qualified<br/>full_name · phone"]
+    C["🏠 shipping_info_collected<br/>shipping_address · shipping_city"]
+    D["✅ user_confirmed<br/>user_confirmation"]
+    E["💳 payment_confirmed<br/>payment_confirmation"]
+
+    A --> B --> C --> D --> E
 ```
 
 > **Nota histórica:** los checkpoints `intent_identified` y `order_created` fueron removidos. `intent` nunca se capturaba de forma confiable (bloqueaba el auto-escalate), y `order_created` requería materializar órdenes en DB — algo que hoy se maneja manualmente por WhatsApp.
@@ -187,22 +153,14 @@ Los demás campos (`product_id`, `full_name`, `phone`, `shipping_*`) se aceptan 
 
 ## Máquina de estados de conversación
 
-```
-              mensaje entrante
-                     │
-                     ▼
-                ┌─────────┐
-         ┌──────┤ active  ├──────┐
-         │      └─────────┘      │
-         │     auto-escalate     │
-         │  (all checkpoints OK) │
-         ▼                       ▼
-  ┌────────────────┐        ┌─────────┐
-  │ human_handoff  │        │ closed  │
-  └────────────────┘        └─────────┘
-         │                       ▲
-         └───────────────────────┘
-              operador cierra
+```mermaid
+stateDiagram-v2
+    [*] --> active : mensaje entrante
+    active --> human_handoff : auto-escalate (all checkpoints OK)
+    active --> closed
+    human_handoff --> active : operador interviene
+    human_handoff --> closed : operador cierra
+    closed --> [*]
 ```
 
 Estados y transiciones permitidas:
@@ -586,5 +544,5 @@ docker run -p 8000:8000 \
 | **Key Vault** | `<KEY_VAULT_NAME>` (DBUSERNAME, DBPASSWORD, DBHOST, DBNAME, sales-ai-service-token) |
 | **Managed Identity** | `<MANAGED_IDENTITY_NAME>` — accede a Key Vault y ACR sin contraseñas en código |
 | **CI/CD** | Push a `main` → GitHub Actions → tests → build Docker → push ACR → rollout Container App |
-| **Cliente demo** | Café Arenillo — ID `00000000-0000-0000-0000-000000000001` |
+| **Cliente** | Café Arenillo — ID `00000000-0000-0000-0000-000000000001` |
 | **n8n** | `https://<N8N_CONTAINER_APP>.azurecontainerapps.io` (orquesta Chakra ↔ backend ↔ OpenAI) |

--- a/sales-ai-docs/CLAUDE.md
+++ b/sales-ai-docs/CLAUDE.md
@@ -15,21 +15,10 @@ Stack: FastAPI (async) + PostgreSQL 16 + asyncpg/SQLAlchemy 2.0. Azure Container
 
 ## Arquitectura en 3 capas
 
-```mermaid
-graph TB
-    subgraph C1["Capa 1 — Lenguaje"]
-        LLM["LLM · gpt-4o-mini\nNLU + NLG · sin tools · sin loops · sin estado"]
-    end
-    subgraph C2["Capa 2 — Política"]
-        POL["GoalStrategyEngine · DAG gates · state machine"]
-    end
-    subgraph C3["Capa 3 — Dominio"]
-        DB["PostgreSQL · ground truth"]
-    end
-    C2 -- directiva --> C1
-    C1 -- extracted_data --> C2
-    C3 -- contexto --> C2
-    C2 -- slots aceptados --> C3
+```
+Capa 1 — Lenguaje:  LLM (NLU + NLG, sin tools, sin loops, sin estado)
+Capa 2 — Política:  GoalStrategyEngine (DAG) + DAG gates + state machine
+Capa 3 — Dominio:   PostgreSQL (ground truth)
 ```
 
 Cada turno = 2 HTTP calls de n8n al backend, 1 LLM call al medio. Sin tool-calling, sin agent loops.
@@ -62,14 +51,10 @@ audit_log            eventos append-only
 
 3 estados actuales (post-refactor 2026-04-19 — ver ADR-007):
 
-```mermaid
-stateDiagram-v2
-    [*] --> active
-    active --> human_handoff : DAG completo (auto-escalate)
-    active --> closed
-    human_handoff --> active : operador interviene
-    human_handoff --> closed
-    closed --> [*]
+```
+active ──► human_handoff ──► closed
+   │              ▲              ▲
+   └──────────────┴──────────────┘
 ```
 
 Toda conversación nueva nace en `active`. Auto-escala a `human_handoff` cuando todos los checkpoints del DAG están completos. `closed` es terminal.
@@ -78,16 +63,23 @@ Toda conversación nueva nace en `active`. Auto-escala a `human_handoff` cuando 
 
 ## DAG de close_sale (vigente)
 
-```mermaid
-graph TD
-    A["📦 product_matched\nproduct_id"]
-    B["👤 lead_qualified\nfull_name · phone"]
-    C["🏠 shipping_info_collected\nshipping_address · shipping_city"]
-    D["✅ user_confirmed\nuser_confirmation\n⚡ gate: full_name + phone + shipping_address + shipping_city"]
-    E["💳 payment_confirmed\npayment_confirmation\n⚡ gate: user_confirmed + phone + shipping_address"]
-    F(["🤝 auto-escalate → human_handoff"])
-
-    A --> B --> C --> D --> E --> F
+```
+product_matched (product_id)
+    │
+    ▼
+lead_qualified (full_name, phone)
+    │
+    ▼
+shipping_info_collected (shipping_address, shipping_city)
+    │
+    ▼
+user_confirmed (user_confirmation)            ← gate: requiere los 4 anteriores
+    │
+    ▼
+payment_confirmed (payment_confirmation)      ← gate: requiere user_confirmed + phone + addr
+    │
+    ▼
+auto-escalate → human_handoff
 ```
 
 NO existen `intent_identified` ni `order_created` (removidos — ver ADR-008 cuando se escriba).
@@ -101,36 +93,38 @@ NO existen `intent_identified` ni `order_created` (removidos — ver ADR-008 cua
 
 ## El patrón de dos llamadas
 
-```mermaid
-sequenceDiagram
-    participant W as WhatsApp
-    participant N as n8n
-    participant B as Backend FastAPI
-    participant L as LLM (gpt-4o-mini)
-    participant DB as PostgreSQL
-
-    W->>N: Webhook Chakra · mensaje del cliente
-
-    N->>B: POST /api/v1/ingest/message
-    B->>DB: Validar client · idempotencia · bloqueo de usuario
-    B->>DB: Upsert client_user · find/create conversación (24h)
-    B->>DB: Advisory lock · persistir mensaje inbound
-    Note over B: Debounce 5s — DEUDA técnica
-    B->>B: GoalStrategyEngine → directive
-    B->>DB: Bump strategy_version · persistir snapshot
-    B-->>N: directive · strategy_version · business_context · recent_messages
-
-    N->>L: system prompt + directive + historial (1 sola llamada, sin tools)
-    L-->>N: response_text + extracted_data
-
-    N->>B: POST /api/v1/agent/action
-    B->>B: Verificar strategy_version (409 si stale — ADR-003)
-    B->>B: DAG gates → merge extracted_data
-    B->>DB: Sync stable facts → client_users.profile
-    B->>DB: Auto-escalate si all_complete · persistir outbound + audit_log
-    B-->>N: approved · final_response_text · side_effects
-
-    N->>W: final_response_text via Chakra
+```
+Mensaje WhatsApp
+    │
+    ▼
+n8n → POST /api/v1/ingest/message
+    │   Backend (1 transacción):
+    │   1. Validar client + idempotencia + bloqueo de usuario
+    │   2. Upsert client_user (ON CONFLICT por phone+client_id)
+    │   3. Conversación (ventana 24h, reset extracted_context si idle 30+ min)
+    │   4. Advisory lock pg_advisory_xact_lock(hash(conv_id))
+    │   5. Persistir mensaje inbound
+    │   6. Debounce 5s (asyncio.sleep — DEUDA, ver "Deuda técnica")
+    │   7. Computar GoalStrategyEngine directive
+    │   8. Bump strategy_version, persistir snapshot
+    │   Devuelve: directive + strategy_version + business_context + ...
+    │
+    ▼
+n8n arma system prompt + llama LLM
+    │   LLM devuelve: response_text + extracted_data
+    │
+    ▼
+n8n → POST /api/v1/agent/action
+    │   Backend:
+    │   1. Verificar strategy_version (409 si stale — ver ADR-003)
+    │   2. Mergear extracted_data con DAG gates
+    │   3. Sync stable facts a client_users.profile
+    │   4. Auto-escalate si all_complete
+    │   5. Persistir outbound message + audit_log
+    │   Devuelve: approved + final_response_text + side_effects
+    │
+    ▼
+n8n envía → WhatsApp via Chakra
 ```
 
 ---
@@ -139,7 +133,7 @@ sequenceDiagram
 
 **Cuando crear una migración** (`migrations/versions/NNN_*.sql`):
 - Cambio de schema de cualquier tabla
-- Cambio de seed data del cliente demo (Café Arenillo)
+- Cambio de seed data de Café Arenillo
 - Cambio del `system_prompt_template` de un cliente
 - Cambio de `business_rules` JSONB que afecta comportamiento del bot
 
@@ -215,7 +209,7 @@ Numeración secuencial. NO modificar migraciones ya aplicadas — siempre crear 
 | Key Vault | `<KEY_VAULT_NAME>` (DBUSERNAME, DBPASSWORD, DBHOST, DBNAME, sales-ai-service-token) |
 | Managed Identity | `<MANAGED_IDENTITY_NAME>` |
 | n8n | `<N8N_CONTAINER_APP>.azurecontainerapps.io` |
-| Cliente demo | Café Arenillo — `00000000-0000-0000-0000-000000000001` |
+| Cliente | Café Arenillo — `00000000-0000-0000-0000-000000000001` |
 | CI/CD | Push a `main` → GitHub Actions → tests + Docker build → ACR push → Container App update |
 
 ---

--- a/sales-ai-docs/docs/architecture/overview.md
+++ b/sales-ai-docs/docs/architecture/overview.md
@@ -134,7 +134,7 @@ Una conversación tiene tres tipos de información distintos, cada uno con su lu
 
 Cada tabla tenant-facing tiene `client_id UUID NOT NULL FK` que apunta a `clients`. Toda query filtra por `client_id`. La separación entre tenants es por convención en la capa de servicio — **no por Row-Level Security de Postgres**. Un bug en una query que olvide el filtro puede leer datos cross-tenant.
 
-Esto es deuda técnica reconocida que se va a tomar al tercer cliente productivo. Para MVP con un cliente demo, está dentro del riesgo aceptado.
+Esto es deuda técnica reconocida que se va a tomar al tercer cliente productivo. Para MVP con un solo cliente, está dentro del riesgo aceptado.
 
 **Customización por cliente** vive en `clients.business_rules` (JSONB):
 - `default_goal`: qué goal del DAG se activa por defecto


### PR DESCRIPTION
## Summary
- **README.md**: convierte 3 diagramas ASCII a Mermaid (sequence, graph TD, stateDiagram) para que rendericen en GitHub
- **CLAUDE.md** (sales-ai-docs): revierte Mermaid a ASCII plano — este archivo es contexto para Claude Code, no se renderiza
- Reemplaza "cliente demo" → "cliente" en docs (Café Arenillo es producción)

## Test plan
- [ ] Verificar que los 3 diagramas Mermaid renderizan correctamente en README.md en GitHub
- [ ] Confirmar que no quedan referencias a "demo" fuera de nombres de migración

🤖 Generated with [Claude Code](https://claude.com/claude-code)