### PR TITLE
fix: validate extracted_data fields + refresh strategy snapshot

### DIFF
--- a/sales_agent_api/app/services/agent_action.py
+++ b/sales_agent_api/app/services/agent_action.py
@@ -21,7 +21,8 @@ from typing import Optional
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.core import AuditLog, Client, ClientUser, Conversation, Message
+from app.models.core import AuditLog, Client, ClientUser, Conversation, Message, Product
+from app.services.field_validators import validate_extracted_data
 from app.services.goal_strategy import GoalStrategyEngine
 from app.services.state_machine import (
     InvalidTransitionError,
@@ -109,6 +110,23 @@ async def process_agent_action(
 
     # --- 3. Persist extracted_data → extracted_context with DAG gates --------
     if extracted_data:
+        # 3a. Field-level validators (rejects ill-formed values like
+        # phone="123456" or shipping_city="acá" before they pollute anything)
+        catalog_rows = await session.execute(
+            select(Product.id).where(
+                Product.client_id == client_id,
+                Product.is_available.is_(True),
+            )
+        )
+        valid_product_ids = {str(pid) for pid in catalog_rows.scalars().all()}
+        extracted_data, rejection_warnings = validate_extracted_data(
+            extracted_data, valid_product_ids=valid_product_ids
+        )
+        if rejection_warnings:
+            side_effects.extend(rejection_warnings)
+            for w in rejection_warnings:
+                logger.warning("Field validation rejected: %s", w)
+
         strategy_updates = {
             k: v for k, v in extracted_data.items()
             if k in STRATEGY_FIELDS and v
@@ -194,6 +212,28 @@ async def process_agent_action(
                 "Auto-escalated conversation %s: all checkpoints complete",
                 conversation.id,
             )
+
+        # Refresh strategy snapshot so the conversation row reflects
+        # the post-merge state (was H4 in the May 2 review: snapshot stayed
+        # at the value from the previous ingest, showing 60% progress on a
+        # conversation that had auto-escalated).
+        await session.execute(
+            update(Conversation)
+            .where(Conversation.id == conversation.id)
+            .values(
+                current_checkpoint=directive.current_checkpoint,
+                progress_pct=directive.progress_pct,
+                strategy_snapshot={
+                    "goal": directive.goal,
+                    "progress_pct": directive.progress_pct,
+                    "current_checkpoint": directive.current_checkpoint,
+                    "missing_fields": directive.missing_fields,
+                    "completed_checkpoints": directive.completed_checkpoints,
+                },
+            )
+        )
+        conversation.current_checkpoint = directive.current_checkpoint
+        conversation.progress_pct = directive.progress_pct
 
     # --- 5. Apply proposed_transition (if any) -------------------------------
     if proposed_transition and proposed_transition != conversation.state:

--- a/sales_agent_api/app/services/field_validators.py
+++ b/sales_agent_api/app/services/field_validators.py
@@ -1,0 +1,191 @@
+"""Field-level validators for the LLM's extracted_data payload.
+
+Why this exists: the LLM has been observed sending values that are syntactically
+valid (truthy strings) but semantically wrong — e.g. phone="123456",
+shipping_city="acá", full_name="Juan". The DAG gates protect ORDER but not
+PRECISION. These validators reject ill-formed values BEFORE they get merged
+into extracted_context or persisted to the customer profile.
+
+Pure Python — no I/O. Each validator returns (is_valid, reason).
+
+Forward compatibility note: when we adopt structured-output (json_schema strict)
+for the LLM call (Fase B), the patterns here become the source of truth for
+the schema as well. Keep validators free of side effects so the rules can be
+serialized into JSON Schema patterns when needed.
+"""
+from __future__ import annotations
+
+import re
+import uuid
+from typing import Any, Callable, Optional
+
+ValidatorResult = tuple[bool, str]
+Validator = Callable[[Any], ValidatorResult]
+
+
+# ---------------------------------------------------------------------------
+# Patterns
+# ---------------------------------------------------------------------------
+# Colombian mobile: 10 digits starting with 3 (e.g. 3001234567).
+# We strip optional country code (57) and non-digit characters before matching.
+_PHONE_RE = re.compile(r"^3\d{9}$")
+
+# Permissive email; good enough for sales context. Not RFC-compliant by design.
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+# Words that mean "here/there" in Spanish — never accept as a city name.
+# The bot was observed capturing "acá" as shipping_city in the past.
+_DEICTIC_CITIES = {
+    "aca", "acá",
+    "aqui", "aquí",
+    "alla", "allá",
+    "ahi", "ahí",
+    "por aqui", "por aquí",
+    "por aca", "por acá",
+    "por alla", "por allá",
+    "aqui mismo", "aquí mismo",
+}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _digits_only(value: Any) -> str:
+    if value is None:
+        return ""
+    return "".join(c for c in str(value) if c.isdigit())
+
+
+def _normalize_phone(value: Any) -> str:
+    """Strip non-digits and the optional Colombia country code (57)."""
+    digits = _digits_only(value)
+    if len(digits) == 12 and digits.startswith("57"):
+        digits = digits[2:]
+    return digits
+
+
+# ---------------------------------------------------------------------------
+# Individual validators
+# ---------------------------------------------------------------------------
+def validate_phone(value: Any) -> ValidatorResult:
+    """Colombian mobile: 10 digits starting with 3 after normalization."""
+    digits = _normalize_phone(value)
+    if not _PHONE_RE.match(digits):
+        return False, f"phone must be Colombian mobile (10 digits starting with 3); got '{value}'"
+    return True, ""
+
+
+def validate_email(value: Any) -> ValidatorResult:
+    if not isinstance(value, str):
+        return False, "email must be a string"
+    if not _EMAIL_RE.match(value.strip()):
+        return False, f"email format invalid: '{value}'"
+    return True, ""
+
+
+def validate_full_name(value: Any) -> ValidatorResult:
+    """At least two words, each ≥2 chars. Avoids 'Juan' or 'A B' passing."""
+    if not isinstance(value, str):
+        return False, "full_name must be a string"
+    parts = value.strip().split()
+    if len(parts) < 2:
+        return False, f"full_name must include first + last name; got '{value}'"
+    if any(len(p) < 2 for p in parts[:2]):
+        return False, f"full_name parts too short: '{value}'"
+    return True, ""
+
+
+def validate_shipping_city(value: Any) -> ValidatorResult:
+    if not isinstance(value, str):
+        return False, "shipping_city must be a string"
+    s = value.strip()
+    if len(s) < 3:
+        return False, f"shipping_city too short: '{value}'"
+    if s.lower() in _DEICTIC_CITIES:
+        return False, f"shipping_city is a deictic word, not a city: '{value}'"
+    return True, ""
+
+
+def validate_quantity(value: Any) -> ValidatorResult:
+    """Positive integer, ≤ 999 (sanity ceiling for a coffee bag order).
+
+    Rejects floats outright — even integer-valued ones — because the LLM
+    sometimes emits 2.0 by mistake and we want to surface that as a warning
+    rather than silently coerce. Booleans are also rejected (Python treats
+    True/False as int subclass).
+    """
+    if isinstance(value, bool) or isinstance(value, float):
+        return False, f"quantity must be an integer, not {type(value).__name__}; got '{value}'"
+    try:
+        n = int(value)
+    except (ValueError, TypeError):
+        return False, f"quantity must be a positive integer; got '{value}'"
+    if n <= 0:
+        return False, f"quantity must be positive; got {n}"
+    if n > 999:
+        return False, f"quantity exceeds sane ceiling (999); got {n}"
+    return True, ""
+
+
+def validate_product_id(
+    value: Any,
+    valid_product_ids: Optional[set[str]] = None,
+) -> ValidatorResult:
+    """Must be a valid UUID. If a catalog set is provided, must be in it.
+
+    Catalog membership is the strong check; UUID format alone catches the
+    common case where the LLM sends the SKU instead of the id.
+    """
+    if not isinstance(value, str):
+        return False, "product_id must be a string"
+    try:
+        u = uuid.UUID(value)
+    except (ValueError, AttributeError):
+        return False, f"product_id is not a valid UUID: '{value}'"
+    if valid_product_ids is not None and str(u) not in valid_product_ids:
+        return False, f"product_id not in catalog: '{value}'"
+    return True, ""
+
+
+# ---------------------------------------------------------------------------
+# Public dict + entry point
+# ---------------------------------------------------------------------------
+# Fields without an entry pass through unvalidated (e.g. boolean confirmations,
+# free-text grind_preference, send_image_url which is gated separately).
+FIELD_VALIDATORS: dict[str, Validator] = {
+    "phone": validate_phone,
+    "email": validate_email,
+    "full_name": validate_full_name,
+    "shipping_city": validate_shipping_city,
+    "quantity": validate_quantity,
+}
+
+
+def validate_extracted_data(
+    extracted_data: dict,
+    valid_product_ids: Optional[set[str]] = None,
+) -> tuple[dict, list[str]]:
+    """Run validators over an extracted_data dict.
+
+    Returns (clean_data, rejection_warnings):
+      - clean_data: same as input minus fields that failed validation
+      - rejection_warnings: side_effect strings ready to surface to the caller
+
+    Fields not in FIELD_VALIDATORS are passed through unchanged (no validation
+    rule defined for them).
+    """
+    clean: dict = {}
+    rejections: list[str] = []
+    for field, value in (extracted_data or {}).items():
+        if field == "product_id":
+            ok, reason = validate_product_id(value, valid_product_ids)
+        elif field in FIELD_VALIDATORS:
+            ok, reason = FIELD_VALIDATORS[field](value)
+        else:
+            ok, reason = True, ""
+        if ok:
+            clean[field] = value
+        else:
+            # Truncate reason to keep side_effect strings manageable.
+            rejections.append(f"warning:invalid_{field}:{reason[:120]}")
+    return clean, rejections

--- a/tests/services/test_field_validators.py
+++ b/tests/services/test_field_validators.py
@@ -1,0 +1,319 @@
+"""Tests for the field_validators service.
+
+Pure Python — no DB, no network. Each validator is exercised against the
+exact patterns we have seen the LLM emit (good and bad).
+"""
+import sys
+import os
+import uuid
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../sales_agent_api"))
+
+from app.services.field_validators import (
+    FIELD_VALIDATORS,
+    validate_email,
+    validate_extracted_data,
+    validate_full_name,
+    validate_phone,
+    validate_product_id,
+    validate_quantity,
+    validate_shipping_city,
+)
+
+
+# ---------------------------------------------------------------------------
+# validate_phone
+# ---------------------------------------------------------------------------
+def test_phone_accepts_canonical_co_mobile():
+    ok, _ = validate_phone("3001234567")
+    assert ok
+
+
+def test_phone_accepts_with_country_code():
+    ok, _ = validate_phone("573001234567")
+    assert ok
+
+
+def test_phone_accepts_with_plus_and_spaces():
+    ok, _ = validate_phone("+57 300 123 4567")
+    assert ok
+
+
+def test_phone_rejects_short_input_observed_may2():
+    """The exact bug from the May 2 review: customer typed '123456'."""
+    ok, reason = validate_phone("123456")
+    assert not ok
+    assert "Colombian" in reason
+
+
+def test_phone_rejects_too_many_digits():
+    ok, _ = validate_phone("12345678910")
+    assert not ok
+
+
+def test_phone_rejects_non_mobile_prefix():
+    """Landlines (start with 6/7/8) are not accepted; we only do mobile."""
+    ok, _ = validate_phone("6041234567")
+    assert not ok
+
+
+def test_phone_rejects_letters():
+    ok, _ = validate_phone("abc")
+    assert not ok
+
+
+def test_phone_rejects_none():
+    ok, _ = validate_phone(None)
+    assert not ok
+
+
+# ---------------------------------------------------------------------------
+# validate_email
+# ---------------------------------------------------------------------------
+def test_email_accepts_simple():
+    ok, _ = validate_email("juan@example.com")
+    assert ok
+
+
+def test_email_accepts_subdomains_and_plus():
+    ok, _ = validate_email("juan+filter@mail.example.co")
+    assert ok
+
+
+def test_email_rejects_no_at():
+    ok, _ = validate_email("juan.example.com")
+    assert not ok
+
+
+def test_email_rejects_no_domain():
+    ok, _ = validate_email("juan@")
+    assert not ok
+
+
+def test_email_rejects_whitespace_inside():
+    ok, _ = validate_email("juan @example.com")
+    assert not ok
+
+
+def test_email_rejects_non_string():
+    ok, _ = validate_email(12345)
+    assert not ok
+
+
+# ---------------------------------------------------------------------------
+# validate_full_name
+# ---------------------------------------------------------------------------
+def test_full_name_accepts_two_words():
+    ok, _ = validate_full_name("Juan Pérez")
+    assert ok
+
+
+def test_full_name_accepts_three_words():
+    ok, _ = validate_full_name("Sebastian Ramirez Rodriguez")
+    assert ok
+
+
+def test_full_name_rejects_first_only():
+    """Bug observed: LLM accepted 'Sebastian' as full_name."""
+    ok, reason = validate_full_name("Sebastian")
+    assert not ok
+    assert "first + last" in reason
+
+
+def test_full_name_rejects_initials():
+    ok, _ = validate_full_name("J P")
+    assert not ok
+
+
+def test_full_name_rejects_empty():
+    ok, _ = validate_full_name("")
+    assert not ok
+
+
+def test_full_name_rejects_whitespace_only():
+    ok, _ = validate_full_name("   ")
+    assert not ok
+
+
+# ---------------------------------------------------------------------------
+# validate_shipping_city
+# ---------------------------------------------------------------------------
+def test_city_accepts_normal():
+    for city in ("Manizales", "Bogotá", "Cali", "Envigado", "San Gil"):
+        ok, _ = validate_shipping_city(city)
+        assert ok, f"should accept {city}"
+
+
+def test_city_rejects_deictic_aca():
+    ok, reason = validate_shipping_city("acá")
+    assert not ok
+    assert "deictic" in reason
+
+
+def test_city_rejects_deictic_aqui():
+    ok, _ = validate_shipping_city("aquí")
+    assert not ok
+
+
+def test_city_rejects_deictic_alla():
+    ok, _ = validate_shipping_city("Allá")  # case-insensitive
+    assert not ok
+
+
+def test_city_rejects_too_short():
+    ok, _ = validate_shipping_city("Bo")
+    assert not ok
+
+
+def test_city_rejects_non_string():
+    ok, _ = validate_shipping_city(123)
+    assert not ok
+
+
+# ---------------------------------------------------------------------------
+# validate_quantity
+# ---------------------------------------------------------------------------
+def test_quantity_accepts_positive_int():
+    for n in (1, 2, 100, 999):
+        ok, _ = validate_quantity(n)
+        assert ok, f"should accept {n}"
+
+
+def test_quantity_accepts_string_int():
+    ok, _ = validate_quantity("4")
+    assert ok
+
+
+def test_quantity_rejects_zero():
+    ok, _ = validate_quantity(0)
+    assert not ok
+
+
+def test_quantity_rejects_negative():
+    ok, _ = validate_quantity(-3)
+    assert not ok
+
+
+def test_quantity_rejects_float():
+    ok, _ = validate_quantity(2.5)
+    assert not ok
+
+
+def test_quantity_rejects_text():
+    ok, _ = validate_quantity("dos")
+    assert not ok
+
+
+def test_quantity_rejects_above_ceiling():
+    ok, _ = validate_quantity(1000)
+    assert not ok
+
+
+# ---------------------------------------------------------------------------
+# validate_product_id
+# ---------------------------------------------------------------------------
+_REAL_UUID = "36d7729d-ce9a-450d-aee6-c9bca665fc63"  # actual Café Arenillo product
+
+
+def test_product_id_accepts_uuid_no_catalog_check():
+    ok, _ = validate_product_id(_REAL_UUID)
+    assert ok
+
+
+def test_product_id_accepts_uuid_in_catalog():
+    ok, _ = validate_product_id(_REAL_UUID, valid_product_ids={_REAL_UUID, "other-uuid"})
+    assert ok
+
+
+def test_product_id_rejects_uuid_not_in_catalog():
+    other = str(uuid.uuid4())
+    ok, reason = validate_product_id(other, valid_product_ids={_REAL_UUID})
+    assert not ok
+    assert "catalog" in reason
+
+
+def test_product_id_rejects_sku_instead_of_uuid():
+    """Common LLM mistake: sending the SKU as product_id."""
+    ok, reason = validate_product_id("CAFE-001")
+    assert not ok
+    assert "UUID" in reason
+
+
+def test_product_id_rejects_garbage():
+    ok, _ = validate_product_id("not-a-uuid-at-all")
+    assert not ok
+
+
+def test_product_id_rejects_non_string():
+    ok, _ = validate_product_id(12345)
+    assert not ok
+
+
+# ---------------------------------------------------------------------------
+# validate_extracted_data (the public entry point)
+# ---------------------------------------------------------------------------
+def test_extracted_data_filters_invalid_fields_keeps_valid():
+    extracted = {
+        "phone": "123456",                # invalid
+        "full_name": "Sebastian",          # invalid (first only)
+        "shipping_city": "Manizales",      # valid
+        "quantity": 4,                     # valid
+        "user_confirmation": True,         # not in validators -> passes through
+    }
+    clean, warnings = validate_extracted_data(extracted)
+    assert "phone" not in clean
+    assert "full_name" not in clean
+    assert clean["shipping_city"] == "Manizales"
+    assert clean["quantity"] == 4
+    assert clean["user_confirmation"] is True
+    assert any("invalid_phone" in w for w in warnings)
+    assert any("invalid_full_name" in w for w in warnings)
+
+
+def test_extracted_data_validates_product_id_against_catalog():
+    catalog = {_REAL_UUID}
+    other = str(uuid.uuid4())
+    clean, warnings = validate_extracted_data(
+        {"product_id": other, "phone": "3001234567"},
+        valid_product_ids=catalog,
+    )
+    assert "product_id" not in clean
+    assert clean["phone"] == "3001234567"
+    assert any("invalid_product_id" in w for w in warnings)
+
+
+def test_extracted_data_empty_input_returns_empty():
+    clean, warnings = validate_extracted_data({})
+    assert clean == {}
+    assert warnings == []
+
+
+def test_extracted_data_none_safe():
+    clean, warnings = validate_extracted_data(None)  # type: ignore[arg-type]
+    assert clean == {}
+    assert warnings == []
+
+
+def test_extracted_data_passes_through_unmapped_fields():
+    """Fields without a validator (e.g. grind_preference) should not be filtered."""
+    clean, warnings = validate_extracted_data(
+        {"grind_preference": "1 molido y 2 grano", "send_image_url": "https://x.com/y.jpg"}
+    )
+    assert clean["grind_preference"] == "1 molido y 2 grano"
+    assert "send_image_url" in clean
+    assert warnings == []
+
+
+def test_extracted_data_warning_format_is_parseable():
+    """Side-effect warnings should follow 'warning:invalid_<field>:<reason>' shape."""
+    _, warnings = validate_extracted_data({"phone": "abc"})
+    assert len(warnings) == 1
+    parts = warnings[0].split(":", 2)
+    assert parts[0] == "warning"
+    assert parts[1] == "invalid_phone"
+    assert len(parts[2]) > 0
+
+
+def test_field_validators_dict_includes_expected_keys():
+    expected = {"phone", "email", "full_name", "shipping_city", "quantity"}
+    assert expected.issubset(set(FIELD_VALIDATORS.keys()))


### PR DESCRIPTION
## Summary

Two fixes from the review of conversation `3c618dca` on May 2:

### 1. Field validators (D1 in the review)

In that conversation Sebastian typed his phone as `"123456"` and the bot accepted it, propagating it into the order summary, the customer profile, and an auto-escalated handoff. Root cause: [agent_action.py](sales_agent_api/app/services/agent_action.py) only filtered `extracted_data` by truthy + whitelist, with zero format checks.

This PR introduces [`services/field_validators.py`](sales_agent_api/app/services/field_validators.py) with regex/format validators for:
- `phone` — Colombian mobile, 10 digits starting with 3 (with country-code stripping)
- `email` — basic format
- `full_name` — must include first + last name (rejects "Sebastian" alone)
- `shipping_city` — non-empty, ≥3 chars, rejects deictic words like "acá"/"aquí"/"allá"
- `quantity` — positive integer ≤999, rejects floats and bools
- `product_id` — must be a valid UUID and (when catalog is provided) a member of the client's product catalog

The wiring in `agent_action.py`:
- Loads the catalog UUIDs once per turn (cheap — same query that `prompt_context.format_business_context` already implies).
- Runs validators BEFORE the existing `STRATEGY_FIELDS` whitelist + DAG gates.
- Invalid fields are dropped from `extracted_data` (so they don't reach the message persisted on `messages.extracted_data` either) and surfaced as `warning:invalid_<field>:<reason>` in `side_effects` for n8n/observability.
- The LLM's `response_text` still reaches the customer (fail-safe pattern, same as the DAG gates).

### 2. Strategy snapshot refresh (H4 in the review)

Discovered while inspecting the May 2 conversation: even though `agent_action` mutates `extracted_context` and runs `GoalStrategyEngine.compute()` for the auto-escalate check, it never persisted the resulting `current_checkpoint`/`progress_pct`/`strategy_snapshot` back to the conversation row. Only `ingest` did. Result: `conversations.current_checkpoint='product_matched'` (60%) on a conversation that had auto-escalated to `human_handoff` after payment_confirmation — a stale snapshot.

Fix: persist the post-merge directive snapshot at the end of section 4 in `process_agent_action`. No new LLM calls, no new DB queries — reuses the directive that's already computed for auto-escalate.

## What is NOT in this PR (kept out by design)

- **Structured-output / Fase B** (json_schema strict in n8n): the validators here are designed to be the source of truth when we serialize them to a JSON Schema for OpenAI's `response_format`. Pure functions, no side effects, easy to translate. Doing both at once would require coordinating with n8n and is bigger than this fix needs to be.
- **Operator notification** (Frente C / PR5).
- **Image-already-sent gate** (PR2, separate).
- **Debounce rearmable** (PR3, separate).

## Test plan

- [x] `pytest tests/ -v` — 110/110 green (64 pre-existing + 46 new)
- [ ] Apply to staging and verify a `phone="123456"` attempt produces `warning:invalid_phone:...` in side_effects and does NOT update extracted_context
- [ ] Verify a `product_id="CAFE-001"` attempt is rejected (catches the "LLM sent SKU instead of UUID" case)
- [ ] After a successful purchase auto-escalate, confirm `conversations.current_checkpoint='all_complete'` and `progress_pct=100` (instead of stale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)