### PR TITLE
fix: drop send_image_url when a prior outbound already carried it

### DIFF
--- a/sales_agent_api/app/services/agent_action.py
+++ b/sales_agent_api/app/services/agent_action.py
@@ -127,6 +127,32 @@ async def process_agent_action(
             for w in rejection_warnings:
                 logger.warning("Field validation rejected: %s", w)
 
+        # 3b. Image-already-sent gate: the system_prompt forbids sending the
+        # product photo more than once per conversation, but during message
+        # bursts two LLM cycles can run in parallel without seeing each
+        # other's outbound and both emit send_image_url. Drop it if any
+        # prior outbound in this conversation already carried it.
+        if extracted_data.get("send_image_url"):
+            prior = await session.execute(
+                select(Message.id)
+                .where(
+                    Message.conversation_id == conversation.id,
+                    Message.direction == "outbound",
+                    Message.extracted_data["send_image_url"].astext.isnot(None),
+                )
+                .limit(1)
+            )
+            image_already_sent = prior.scalar_one_or_none() is not None
+            extracted_data, image_warnings = _filter_send_image_url(
+                extracted_data, image_already_sent=image_already_sent
+            )
+            if image_warnings:
+                side_effects.extend(image_warnings)
+                logger.warning(
+                    "Dropped send_image_url for conversation %s: prior outbound already carried it",
+                    conversation.id,
+                )
+
         strategy_updates = {
             k: v for k, v in extracted_data.items()
             if k in STRATEGY_FIELDS and v
@@ -349,6 +375,24 @@ async def _merge_profile(
         .where(ClientUser.id == client_user_id)
         .values(profile=profile)
     )
+
+
+def _filter_send_image_url(
+    extracted_data: dict,
+    image_already_sent: bool,
+) -> tuple[dict, list[str]]:
+    """Drop send_image_url from extracted_data if a prior outbound in the
+    same conversation already carried one. Returns (clean_data, warnings).
+
+    Pure function so it can be unit-tested without a DB. The DB query that
+    determines image_already_sent lives in process_agent_action.
+    """
+    if not extracted_data.get("send_image_url"):
+        return extracted_data, []
+    if not image_already_sent:
+        return extracted_data, []
+    clean = {k: v for k, v in extracted_data.items() if k != "send_image_url"}
+    return clean, ["warning:image_already_sent"]
 
 
 async def _bump_lifecycle_stage(

--- a/tests/services/test_image_gate.py
+++ b/tests/services/test_image_gate.py
@@ -1,0 +1,75 @@
+"""Tests for the image-already-sent gate helper.
+
+Pure Python — the DB lookup that decides image_already_sent lives in
+process_agent_action; the filter logic itself is a pure function so it can
+be tested in isolation.
+"""
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../sales_agent_api"))
+
+from app.services.agent_action import _filter_send_image_url
+
+
+def test_passes_through_when_no_image_in_payload():
+    """Nothing to filter — extracted_data has no send_image_url."""
+    data = {"phone": "3001234567", "full_name": "Juan Pérez"}
+    clean, warnings = _filter_send_image_url(data, image_already_sent=False)
+    assert clean == data
+    assert warnings == []
+
+
+def test_passes_through_when_no_image_even_if_flag_set():
+    """The flag only matters when send_image_url is present."""
+    data = {"phone": "3001234567"}
+    clean, warnings = _filter_send_image_url(data, image_already_sent=True)
+    assert clean == data
+    assert warnings == []
+
+
+def test_keeps_image_when_not_yet_sent():
+    """First time the LLM emits the image — let it through."""
+    data = {"send_image_url": "https://example.com/coffee.jpg", "phone": "3001234567"}
+    clean, warnings = _filter_send_image_url(data, image_already_sent=False)
+    assert clean == data
+    assert warnings == []
+
+
+def test_drops_image_when_already_sent():
+    """Second emission of the same image — drop it, emit warning."""
+    data = {"send_image_url": "https://example.com/coffee.jpg", "phone": "3001234567"}
+    clean, warnings = _filter_send_image_url(data, image_already_sent=True)
+    assert "send_image_url" not in clean
+    assert clean["phone"] == "3001234567"
+    assert warnings == ["warning:image_already_sent"]
+
+
+def test_does_not_mutate_input():
+    """Caller may inspect extracted_data after — don't mutate it in place."""
+    data = {"send_image_url": "https://x.jpg", "phone": "3001234567"}
+    snapshot = dict(data)
+    _filter_send_image_url(data, image_already_sent=True)
+    assert data == snapshot
+
+
+def test_handles_empty_input():
+    clean, warnings = _filter_send_image_url({}, image_already_sent=True)
+    assert clean == {}
+    assert warnings == []
+
+
+def test_treats_empty_string_as_no_image():
+    """LLM sometimes emits send_image_url='' when it shouldn't have set the
+    field at all. Empty string is falsy → nothing to gate."""
+    data = {"send_image_url": "", "phone": "3001234567"}
+    clean, warnings = _filter_send_image_url(data, image_already_sent=True)
+    assert clean == data
+    assert warnings == []
+
+
+def test_treats_none_as_no_image():
+    data = {"send_image_url": None, "phone": "3001234567"}
+    clean, warnings = _filter_send_image_url(data, image_already_sent=True)
+    assert clean == data
+    assert warnings == []


### PR DESCRIPTION
## Summary

Fixes the duplicate-image bug from conversation `3c618dca` (May 2, 10:53). Sebastian sent two messages in 5 seconds, both LLM cycles ran in parallel without seeing each other's outbound, both emitted `send_image_url`, and Chakra sent the same image twice.

## What changes

In [`agent_action.py`](sales_agent_api/app/services/agent_action.py): before persisting `extracted_data`, if `send_image_url` is present AND any prior outbound in the conversation already has one (`messages.extracted_data->>'send_image_url' IS NOT NULL`), drop the field and emit `warning:image_already_sent` in `side_effects`.

Extracted the filter as a pure function `_filter_send_image_url(data, image_already_sent)` so it can be unit-tested without a DB. The async catalog lookup that determines `image_already_sent` stays in `process_agent_action`.

## Scope of effectiveness — read this carefully

- **What this PR fixes**: cleans up `messages.extracted_data` so the LLM in subsequent turns sees only one image-send in history. The persisted record matches what was actually intended.

- **What this PR does NOT fix**: the duplicate WhatsApp send to the customer in the original race scenario. n8n's `Process Backend Response` node reads `send_image_url` from `prev.action_body` (the body it sent to backend), NOT from the backend's response. So even if backend drops the field, n8n still triggers `Send Product Image` because its own `prev.action_body` still has the URL.

- **The customer-visible fix** comes from PR3 (debounce rearmable) which prevents the race from happening in the first place.

- **A future cleanup** could extend this PR by:
  - Returning `extracted_data` (filtered) in the agent_action response, AND
  - Updating n8n's `Process Backend Response` to read from the backend response

That would close the loophole completely. Not in this PR's scope to keep it minimal and to avoid coupling backend deploys with n8n workflow changes.

## Why ship this anyway?

Three reasons:
1. The cleaner persisted record means the LLM's `recent_messages` history won't show "agent sent image twice", which would otherwise risk the LLM apologizing for or referencing the duplicate in subsequent turns.
2. Defense-in-depth: when PR3 lands and the race is mostly closed, this gate catches the rare residual case.
3. Sets a precedent for backend-side gates on extracted_data fields, parallel to the field validators in PR #38.

## Test plan
- [x] `pytest tests/ -v` — 72/72 green (64 pre-existing + 8 new)
- [ ] Apply to staging. Trigger the race (send "foto?" + "quiero verla" within 3-4s). Verify `messages.extracted_data` of the second outbound does NOT contain `send_image_url` and `side_effects` includes `warning:image_already_sent`.
- [ ] Confirm Chakra still sends the image twice (pending PR3 for the user-visible fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)