### PR TITLE
fix: rearmable debounce — only the last message in a burst responds

### DIFF
--- a/sales_agent_api/app/services/ingest.py
+++ b/sales_agent_api/app/services/ingest.py
@@ -21,7 +21,7 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
-from sqlalchemy import select, update, text
+from sqlalchemy import func, select, update, text
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -207,26 +207,29 @@ async def ingest_message(
     conversation.message_count += 1
     conversation.last_message_at = now
 
-    # --- 8b. Rapid-fire debounce ---------------------------------------------
-    # Flush to persist the message, then commit to release the advisory lock
-    # so other messages from the same user can be inserted. Sleep briefly,
-    # then check if a newer inbound arrived — if so, let that one respond.
+    # --- 8b. Rapid-fire debounce (rearmable) ---------------------------------
+    # Goal: only the LAST inbound in a burst gets to respond. We poll every
+    # POLL_INTERVAL seconds; if a newer inbound has arrived we bail (that
+    # one will respond instead). If no newer inbound has arrived AND enough
+    # silence has accumulated since the latest inbound (which is us), we
+    # proceed. A MAX_WAIT cap prevents indefinite blocking when the customer
+    # keeps typing.
+    #
+    # Rationale (vs the previous fixed asyncio.sleep(5)): the old logic
+    # measured silence from MY message timestamp, so two messages 5s apart
+    # both passed and both responded — the bug observed in conversation
+    # 3c618dca on May 2 (foto duplicada) and listed as deuda #2 in CLAUDE.md.
     await session.flush()
     await session.commit()
-    await asyncio.sleep(5)
 
-    newer_msg = await session.execute(
-        select(Message.id)
-        .where(
-            Message.conversation_id == conversation.id,
-            Message.direction == "inbound",
-            Message.created_at > msg_timestamp,
-        )
-        .limit(1)
+    debounce_decision = await _wait_for_silence(
+        session=session,
+        conversation_id=conversation.id,
+        my_msg_timestamp=msg_timestamp,
     )
-    if newer_msg.scalar_one_or_none() is not None:
+    if debounce_decision == "bail":
         logger.info(
-            "Debounce: newer message exists, skipping response for %s",
+            "Debounce: newer message arrived, skipping response for %s",
             chakra_message_id,
         )
         return {"should_respond": False, "reason": "debounce"}
@@ -421,3 +424,79 @@ def _mask_phone(phone: str) -> str:
     if len(phone) <= 4:
         return "****"
     return "*" * (len(phone) - 4) + phone[-4:]
+
+
+# ---------------------------------------------------------------------------
+# Rearmable debounce (paso 8b)
+# ---------------------------------------------------------------------------
+# Tunables. Keep MAX_WAIT comfortably under n8n's HTTP timeout (5 min default).
+DEBOUNCE_POLL_INTERVAL = 2.0     # seconds between polls
+DEBOUNCE_SILENCE_REQUIRED = 5.0  # seconds of silence to proceed
+DEBOUNCE_MAX_WAIT = 15.0         # cap total wait per ingest
+
+
+def evaluate_debounce_state(
+    my_msg_timestamp: datetime,
+    latest_inbound_ts: Optional[datetime],
+    now: datetime,
+    silence_required_seconds: float = DEBOUNCE_SILENCE_REQUIRED,
+) -> str:
+    """Pure decision function for one debounce poll cycle.
+
+    Returns one of:
+      - "proceed": this ingest should respond (silence achieved)
+      - "bail":    a newer inbound arrived; this ingest should debounce
+      - "wait":    keep polling
+
+    The caller controls the actual sleeping and the MAX_WAIT cap.
+    """
+    if latest_inbound_ts is not None and latest_inbound_ts > my_msg_timestamp:
+        return "bail"
+    reference = latest_inbound_ts or my_msg_timestamp
+    elapsed = (now - reference).total_seconds()
+    if elapsed >= silence_required_seconds:
+        return "proceed"
+    return "wait"
+
+
+async def _wait_for_silence(
+    session: AsyncSession,
+    conversation_id: uuid.UUID,
+    my_msg_timestamp: datetime,
+) -> str:
+    """Poll until silence is achieved or a newer inbound arrives.
+
+    Returns "proceed" or "bail". Hits "proceed" automatically after
+    DEBOUNCE_MAX_WAIT seconds even if the customer is still typing —
+    the alternative is unbounded blocking.
+    """
+    loop = asyncio.get_event_loop()
+    started_at = loop.time()
+    while True:
+        await asyncio.sleep(DEBOUNCE_POLL_INTERVAL)
+
+        latest_row = await session.execute(
+            select(func.max(Message.created_at)).where(
+                Message.conversation_id == conversation_id,
+                Message.direction == "inbound",
+            )
+        )
+        latest_ts: Optional[datetime] = latest_row.scalar_one_or_none()
+
+        decision = evaluate_debounce_state(
+            my_msg_timestamp=my_msg_timestamp,
+            latest_inbound_ts=latest_ts,
+            now=datetime.now(timezone.utc),
+        )
+        if decision == "proceed":
+            return "proceed"
+        if decision == "bail":
+            return "bail"
+
+        # Cap total wait so an actively-typing customer eventually gets a reply.
+        if loop.time() - started_at >= DEBOUNCE_MAX_WAIT:
+            logger.warning(
+                "Debounce: hit MAX_WAIT (%.0fs) for conversation %s; proceeding anyway",
+                DEBOUNCE_MAX_WAIT, conversation_id,
+            )
+            return "proceed"

--- a/tests/services/test_debounce.py
+++ b/tests/services/test_debounce.py
@@ -1,0 +1,167 @@
+"""Tests for the rearmable-debounce decision function.
+
+Pure Python — exercises evaluate_debounce_state across the four key
+scenarios. The async polling loop (_wait_for_silence) is exercised in
+integration tests (pending) since it requires a DB and asyncio.sleep.
+"""
+import sys
+import os
+from datetime import datetime, timedelta, timezone
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../sales_agent_api"))
+
+from app.services.ingest import (
+    DEBOUNCE_SILENCE_REQUIRED,
+    evaluate_debounce_state,
+)
+
+
+UTC = timezone.utc
+
+
+def _ts(seconds_from_t0: float) -> datetime:
+    """Helper: deterministic timestamp at T0 + seconds."""
+    return datetime(2026, 5, 3, 12, 0, 0, tzinfo=UTC) + timedelta(seconds=seconds_from_t0)
+
+
+# ---------------------------------------------------------------------------
+# Bail scenarios — a newer inbound arrived
+# ---------------------------------------------------------------------------
+def test_bail_when_newer_inbound_exists():
+    """Customer sent another message after mine — let it respond instead."""
+    decision = evaluate_debounce_state(
+        my_msg_timestamp=_ts(0),
+        latest_inbound_ts=_ts(3),  # newer than me
+        now=_ts(5),
+    )
+    assert decision == "bail"
+
+
+def test_bail_when_newer_inbound_by_microseconds():
+    """Edge case: newer by even a microsecond should bail."""
+    decision = evaluate_debounce_state(
+        my_msg_timestamp=_ts(0),
+        latest_inbound_ts=_ts(0.000001),
+        now=_ts(5),
+    )
+    assert decision == "bail"
+
+
+def test_bail_takes_priority_over_silence():
+    """Even if SILENCE_REQUIRED has passed, bail if a newer message exists."""
+    decision = evaluate_debounce_state(
+        my_msg_timestamp=_ts(0),
+        latest_inbound_ts=_ts(3),
+        now=_ts(100),  # tons of silence since the newer one
+    )
+    assert decision == "bail"
+
+
+# ---------------------------------------------------------------------------
+# Proceed scenarios — I am the latest and silence is enough
+# ---------------------------------------------------------------------------
+def test_proceed_when_silence_achieved_with_self_as_latest():
+    decision = evaluate_debounce_state(
+        my_msg_timestamp=_ts(0),
+        latest_inbound_ts=_ts(0),  # I am the latest
+        now=_ts(DEBOUNCE_SILENCE_REQUIRED),
+    )
+    assert decision == "proceed"
+
+
+def test_proceed_when_silence_well_beyond_required():
+    decision = evaluate_debounce_state(
+        my_msg_timestamp=_ts(0),
+        latest_inbound_ts=_ts(0),
+        now=_ts(60),
+    )
+    assert decision == "proceed"
+
+
+def test_proceed_when_no_inbound_visible_yet():
+    """Edge case: query returned NULL (rare, e.g. row not yet visible).
+    Falls back to using my own timestamp as the silence anchor."""
+    decision = evaluate_debounce_state(
+        my_msg_timestamp=_ts(0),
+        latest_inbound_ts=None,
+        now=_ts(DEBOUNCE_SILENCE_REQUIRED + 1),
+    )
+    assert decision == "proceed"
+
+
+# ---------------------------------------------------------------------------
+# Wait scenarios — I am the latest but not enough silence yet
+# ---------------------------------------------------------------------------
+def test_wait_when_silence_not_yet_achieved():
+    decision = evaluate_debounce_state(
+        my_msg_timestamp=_ts(0),
+        latest_inbound_ts=_ts(0),
+        now=_ts(DEBOUNCE_SILENCE_REQUIRED - 0.001),
+    )
+    assert decision == "wait"
+
+
+def test_wait_when_just_arrived():
+    decision = evaluate_debounce_state(
+        my_msg_timestamp=_ts(0),
+        latest_inbound_ts=_ts(0),
+        now=_ts(0.5),
+    )
+    assert decision == "wait"
+
+
+def test_wait_when_no_inbound_and_no_silence_yet():
+    decision = evaluate_debounce_state(
+        my_msg_timestamp=_ts(0),
+        latest_inbound_ts=None,
+        now=_ts(1),
+    )
+    assert decision == "wait"
+
+
+# ---------------------------------------------------------------------------
+# Silence_required override
+# ---------------------------------------------------------------------------
+def test_silence_required_can_be_overridden():
+    """Useful for tests and for tuning under load."""
+    decision = evaluate_debounce_state(
+        my_msg_timestamp=_ts(0),
+        latest_inbound_ts=_ts(0),
+        now=_ts(2),
+        silence_required_seconds=1.0,
+    )
+    assert decision == "proceed"
+
+
+# ---------------------------------------------------------------------------
+# Scenario from the May 2 bug — replayed
+# ---------------------------------------------------------------------------
+def test_may2_bug_replay_first_message_should_bail():
+    """In the original bug:
+       - M1 'Tienes una foto?' at 10:53:05
+       - M2 'Quiero ver la presentación' at 10:53:10
+    Old logic: M1 waited 5s → 10:53:10, found nothing strictly newer → proceeded.
+    M2 then ran independently → also proceeded → two photos sent.
+    New logic with rearmable poll: M1's poll at 10:53:07 (poll_interval=2s)
+    sees M2 already in the table → bail."""
+    m1_ts = _ts(0)        # 10:53:05
+    m2_ts = _ts(5)        # 10:53:10 — newer than m1
+    poll_at = _ts(7)      # m1's first poll, 2s after entering debounce
+    decision = evaluate_debounce_state(
+        my_msg_timestamp=m1_ts,
+        latest_inbound_ts=m2_ts,
+        now=poll_at,
+    )
+    assert decision == "bail"
+
+
+def test_may2_bug_replay_second_message_proceeds_after_silence():
+    """Same scenario: M2 keeps polling. After 5s of silence since M2
+    arrived (i.e. T=10s on M2 timeline), M2 proceeds."""
+    m2_ts = _ts(5)
+    decision = evaluate_debounce_state(
+        my_msg_timestamp=m2_ts,
+        latest_inbound_ts=m2_ts,    # m2 is the latest
+        now=_ts(10),                # 5s after m2
+    )
+    assert decision == "proceed"


### PR DESCRIPTION
## Summary

Fixes the root cause of the duplicate-photo bug from conversation `3c618dca` (May 2). The previous debounce slept `asyncio.sleep(5)` once and checked for a newer inbound. Two messages 5s apart both passed independently, both hit the LLM, both responded.

This is **deuda #2** in `CLAUDE.md` ("Debounce con asyncio.sleep(5)") and the underlying mechanism behind:
- Duplicate photos (Sebastian's case: "¿foto?" + "Quiero verla" 5s apart)
- Duplicate goodbye messages (Jacobo's case: "ok, gracias" → two outbounds)
- Any other case where the LLM responds to two near-simultaneous inbounds in parallel.

## How it works now

```
loop:
   sleep 2s
   latest_ts = MAX(created_at) WHERE conversation_id=X AND direction='inbound'
   decision = evaluate_debounce_state(my_ts, latest_ts, now)
     → "bail":    a newer inbound exists, this ingest gives up
     → "proceed": I am latest AND silence ≥ 5s, respond now
     → "wait":    keep polling
   if elapsed > 15s: proceed anyway (cap)
```

Property: only the LAST message in a burst proceeds. Every earlier one detects the newer one on its next poll and bails.

The `MAX_WAIT` cap (15s) is comfortably under n8n's HTTP timeout (5min default per the workflow analysis).

## Why the polling-loop design

Three other approaches were considered:

1. **DB advisory lock per conversation**: would serialize access but doesn't decide who responds — still need silence detection.
2. **Single longer sleep + check**: same bug, just less frequent.
3. **Cancel-and-replace**: each new ingest cancels the previous task. Hard to coordinate across stateless requests.

The polling loop is the simplest design that gives the right semantics. The cost is at most 7 extra DB queries per ingest (one per poll) at low volume, which is negligible.

## Implementation notes

- `evaluate_debounce_state(my_ts, latest_ts, now) -> str` is a pure function — easy to unit-test.
- `_wait_for_silence` does the async polling and DB queries, calling `evaluate_debounce_state` for the decision.
- Tunables (`DEBOUNCE_POLL_INTERVAL`, `DEBOUNCE_SILENCE_REQUIRED`, `DEBOUNCE_MAX_WAIT`) are module-level constants — easy to adjust if we hit production tuning needs.

## Interaction with PR #39 (image-already-sent gate)

PR3 prevents the race in the first place. PR #39 catches the residual case where the race still happens (different message types, different timing). Defense in depth.

## Test plan
- [x] `pytest tests/ -v` — 122/122 green (110 pre-existing + 12 new)
- [ ] Apply to staging. Send rapid-fire messages (3 inbounds within 4s). Verify:
  - Only ONE outbound is sent (the response to the LAST inbound).
  - The earlier ingests log `"Debounce: newer message arrived, skipping"` and return `should_respond: false`.
- [ ] Send a single message. Verify response arrives within ~5-7s (one poll cycle past the silence requirement).
- [ ] Stress test: send 10 messages in a row, verify only the 10th responds, MAX_WAIT cap not hit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)