### PR TITLE
feat: n8n heartbeat + integration-health endpoint (L3 / deuda #3)

### DIFF
--- a/migrations/versions/010_audit_log_event_index.sql
+++ b/migrations/versions/010_audit_log_event_index.sql
@@ -1,0 +1,20 @@
+-- Migration 010: Index for audit_log health queries
+--
+-- The /api/v1/internal/integration-health endpoint queries audit_log for
+-- the most recent n8n_ping event ("when did we last hear from n8n?"). The
+-- table also receives a heartbeat per minute, so it grows steadily — without
+-- an index, the lookup degrades from O(1) to O(N) over time.
+--
+-- This index supports both the n8n-ping freshness query and any future
+-- "events of type X in the last N minutes" query without scanning the
+-- whole table.
+--
+-- Applied: 2026-05-03
+
+CREATE INDEX IF NOT EXISTS ix_audit_log_event_created
+  ON audit_log (event_type, created_at DESC);
+
+COMMENT ON INDEX ix_audit_log_event_created IS
+  'Supports observability queries on audit_log: "last event of type X" and
+   "events of type X since T". Critical for /api/v1/internal/integration-health
+   which polls the latest n8n_ping timestamp on every check.';

--- a/sales_agent_api/app/api/v1/internal.py
+++ b/sales_agent_api/app/api/v1/internal.py
@@ -1,0 +1,81 @@
+"""Internal observability endpoints.
+
+  POST /api/v1/internal/n8n-ping        — heartbeat from n8n every ~60s
+  GET  /api/v1/internal/integration-health — read the freshness + stuck count
+
+Auth: same Bearer + X-Client-ID as the rest of /api/v1. n8n includes the
+client_id of the subworkflow whose health is being reported (Café Arenillo
+today; future tenants will identify themselves the same way).
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_session
+from app.services.integration_health import (
+    get_integration_health,
+    record_n8n_ping,
+)
+
+router = APIRouter()
+
+
+class N8nPingRequest(BaseModel):
+    workflow_name: Optional[str] = None
+    execution_id: Optional[str] = None
+
+
+class N8nPingResponse(BaseModel):
+    recorded: bool
+
+
+@router.post("/n8n-ping", response_model=N8nPingResponse)
+async def n8n_ping(
+    request: Request,
+    body: N8nPingRequest,
+    session: AsyncSession = Depends(get_session),
+) -> N8nPingResponse:
+    """Append a heartbeat row to audit_log and commit.
+
+    Idempotency is not required — duplicate pings are harmless extra rows.
+    """
+    client_id: uuid.UUID = request.state.client_id
+    try:
+        await record_n8n_ping(
+            session=session,
+            client_id=client_id,
+            workflow_name=body.workflow_name,
+            execution_id=body.execution_id,
+        )
+        await session.commit()
+        return N8nPingResponse(recorded=True)
+    except Exception as exc:
+        await session.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"n8n_ping persistence failed: {exc}",
+        )
+
+
+@router.get("/integration-health")
+async def integration_health(
+    request: Request,
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    """Snapshot of n8n freshness + stuck conversations for this client.
+
+    No commit — read-only.
+    """
+    client_id: uuid.UUID = request.state.client_id
+    try:
+        return await get_integration_health(session=session, client_id=client_id)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"integration_health query failed: {exc}",
+        )

--- a/sales_agent_api/app/main.py
+++ b/sales_agent_api/app/main.py
@@ -134,9 +134,11 @@ def create_app() -> FastAPI:
     # Register routers
     from app.api.v1.ingest import router as ingest_router
     from app.api.v1.agent import router as agent_router
+    from app.api.v1.internal import router as internal_router
 
     application.include_router(ingest_router, prefix="/api/v1/ingest", tags=["Ingest"])
     application.include_router(agent_router, prefix="/api/v1/agent", tags=["Agent"])
+    application.include_router(internal_router, prefix="/api/v1/internal", tags=["Internal"])
 
     @application.get("/health", tags=["Health"])
     async def health():

--- a/sales_agent_api/app/services/integration_health.py
+++ b/sales_agent_api/app/services/integration_health.py
@@ -1,0 +1,173 @@
+"""Integration health: n8n heartbeat + stuck-conversation detector.
+
+Why this exists: prior to this service, if the n8n cafe_arenillo_v2
+subworkflow stopped firing (ID changed, trigger broken, container down),
+the backend had no way to know — the only signal was customer messages
+not getting answered. Documented as deuda #3 in CLAUDE.md and as
+limitation L3 in the README ("Fallo silencioso del subworkflow").
+
+Two health signals exposed:
+
+1. n8n freshness — n8n posts to /api/v1/internal/n8n-ping every 60s. We
+   record it as an audit_log event and expose how stale the latest one is.
+
+2. Stuck conversations — for each client, count conversations whose
+   latest message is inbound (we owe a reply) and where last_message_at
+   is older than STUCK_AFTER_SECONDS. A non-zero count means either n8n
+   isn't delivering the ingest, or backend rejected the agent_action,
+   or some mid-flow failure. Either way, customers are waiting.
+
+Both signals are scoped per client_id (multi-tenant), so a future operator
+dashboard can show per-tenant integration status.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from sqlalchemy import and_, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.core import AuditLog, Conversation, Message
+
+logger = logging.getLogger(__name__)
+
+
+# Tunables. STUCK_AFTER_SECONDS is generous on purpose — under the new
+# rearmable debounce, normal turns can take up to 15s, so 120s gives plenty
+# of headroom before flagging as stuck.
+STUCK_AFTER_SECONDS = 120
+N8N_HEALTHY_WITHIN_SECONDS = 180   # < 3 min since last ping → healthy
+N8N_STALE_WITHIN_SECONDS = 600     # 3-10 min → stale; > 10 min → dead
+
+# Sentinel UUID used as the entity_id for every n8n_ping audit_log row.
+# A fixed value (instead of a fresh uuid4 per ping) keeps the audit trail
+# scannable: WHERE entity_id = N8N_PING_ENTITY_ID lists the full heartbeat
+# history without joining anything else.
+N8N_PING_ENTITY_ID = uuid.UUID("00000000-0000-0000-0000-000000000031")
+
+
+# ---------------------------------------------------------------------------
+# Recording
+# ---------------------------------------------------------------------------
+async def record_n8n_ping(
+    session: AsyncSession,
+    client_id: uuid.UUID,
+    workflow_name: Optional[str] = None,
+    execution_id: Optional[str] = None,
+) -> None:
+    """Append a heartbeat row to audit_log. Caller controls commit."""
+    payload = {"workflow_name": workflow_name, "execution_id": execution_id}
+    session.add(
+        AuditLog(
+            client_id=client_id,
+            event_type="n8n_ping",
+            entity_type="n8n_workflow",
+            entity_id=N8N_PING_ENTITY_ID,
+            actor_type="system",
+            new_value={k: v for k, v in payload.items() if v is not None},
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reading
+# ---------------------------------------------------------------------------
+async def get_integration_health(
+    session: AsyncSession,
+    client_id: uuid.UUID,
+    now: Optional[datetime] = None,
+) -> dict:
+    """Build the integration-health snapshot for one client."""
+    now = now or datetime.now(timezone.utc)
+
+    last_ping_row = await session.execute(
+        select(func.max(AuditLog.created_at)).where(
+            AuditLog.client_id == client_id,
+            AuditLog.event_type == "n8n_ping",
+        )
+    )
+    last_ping_at: Optional[datetime] = last_ping_row.scalar_one_or_none()
+
+    stuck = await _count_stuck_conversations(session, client_id, now=now)
+
+    return {
+        "n8n": _summarize_n8n_freshness(last_ping_at, now=now),
+        "stuck_conversations": stuck,
+        "checked_at": now.isoformat(),
+    }
+
+
+def _summarize_n8n_freshness(
+    last_ping_at: Optional[datetime],
+    now: datetime,
+) -> dict:
+    """Pure function: classify n8n ping freshness."""
+    if last_ping_at is None:
+        return {"status": "unknown", "last_ping_at": None, "seconds_since_last_ping": None}
+    seconds = int((now - last_ping_at).total_seconds())
+    if seconds <= N8N_HEALTHY_WITHIN_SECONDS:
+        status = "healthy"
+    elif seconds <= N8N_STALE_WITHIN_SECONDS:
+        status = "stale"
+    else:
+        status = "dead"
+    return {
+        "status": status,
+        "last_ping_at": last_ping_at.isoformat(),
+        "seconds_since_last_ping": seconds,
+    }
+
+
+async def _count_stuck_conversations(
+    session: AsyncSession,
+    client_id: uuid.UUID,
+    now: datetime,
+    stuck_after_seconds: int = STUCK_AFTER_SECONDS,
+) -> dict:
+    """Conversations where the latest message is inbound and old enough
+    that we should have answered by now."""
+    threshold = now - timedelta(seconds=stuck_after_seconds)
+
+    # For each conversation in this client, find the latest message and check
+    # if it is inbound + older than threshold.
+    latest_per_conv = (
+        select(
+            Message.conversation_id.label("cid"),
+            func.max(Message.created_at).label("latest_ts"),
+        )
+        .where(Message.client_id == client_id)
+        .group_by(Message.conversation_id)
+        .subquery()
+    )
+    stuck_q = (
+        select(Conversation.id, Message.created_at)
+        .join(latest_per_conv, latest_per_conv.c.cid == Conversation.id)
+        .join(
+            Message,
+            and_(
+                Message.conversation_id == Conversation.id,
+                Message.created_at == latest_per_conv.c.latest_ts,
+            ),
+        )
+        .where(
+            Conversation.client_id == client_id,
+            Conversation.state.in_(("active", "human_handoff")),
+            Message.direction == "inbound",
+            Message.created_at < threshold,
+        )
+        .order_by(Message.created_at.asc())
+        .limit(10)
+    )
+    rows = (await session.execute(stuck_q)).all()
+    examples = [
+        {
+            "conversation_id": str(cid),
+            "last_inbound_at": ts.isoformat(),
+            "minutes_pending": int((now - ts).total_seconds() // 60),
+        }
+        for cid, ts in rows
+    ]
+    return {"count": len(examples), "examples": examples}

--- a/tests/services/test_integration_health.py
+++ b/tests/services/test_integration_health.py
@@ -1,0 +1,95 @@
+"""Tests for the integration_health service.
+
+Pure Python — covers the pure decision function (_summarize_n8n_freshness).
+The DB-touching record_n8n_ping and _count_stuck_conversations are exercised
+in integration tests (pending — see CLAUDE.md deuda #1).
+"""
+import sys
+import os
+from datetime import datetime, timedelta, timezone
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../sales_agent_api"))
+
+from app.services.integration_health import (
+    N8N_HEALTHY_WITHIN_SECONDS,
+    N8N_PING_ENTITY_ID,
+    N8N_STALE_WITHIN_SECONDS,
+    STUCK_AFTER_SECONDS,
+    _summarize_n8n_freshness,
+)
+
+
+UTC = timezone.utc
+NOW = datetime(2026, 5, 3, 12, 0, 0, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# _summarize_n8n_freshness
+# ---------------------------------------------------------------------------
+def test_unknown_when_no_ping_ever():
+    out = _summarize_n8n_freshness(last_ping_at=None, now=NOW)
+    assert out["status"] == "unknown"
+    assert out["last_ping_at"] is None
+    assert out["seconds_since_last_ping"] is None
+
+
+def test_healthy_when_recent():
+    last = NOW - timedelta(seconds=30)
+    out = _summarize_n8n_freshness(last_ping_at=last, now=NOW)
+    assert out["status"] == "healthy"
+    assert out["seconds_since_last_ping"] == 30
+    assert out["last_ping_at"] == last.isoformat()
+
+
+def test_healthy_at_boundary():
+    last = NOW - timedelta(seconds=N8N_HEALTHY_WITHIN_SECONDS)
+    out = _summarize_n8n_freshness(last_ping_at=last, now=NOW)
+    assert out["status"] == "healthy"
+
+
+def test_stale_just_past_healthy_boundary():
+    last = NOW - timedelta(seconds=N8N_HEALTHY_WITHIN_SECONDS + 1)
+    out = _summarize_n8n_freshness(last_ping_at=last, now=NOW)
+    assert out["status"] == "stale"
+
+
+def test_stale_at_dead_boundary():
+    last = NOW - timedelta(seconds=N8N_STALE_WITHIN_SECONDS)
+    out = _summarize_n8n_freshness(last_ping_at=last, now=NOW)
+    assert out["status"] == "stale"
+
+
+def test_dead_when_well_past_stale_window():
+    last = NOW - timedelta(seconds=N8N_STALE_WITHIN_SECONDS + 1)
+    out = _summarize_n8n_freshness(last_ping_at=last, now=NOW)
+    assert out["status"] == "dead"
+
+
+def test_dead_for_very_old_ping():
+    last = NOW - timedelta(hours=24)
+    out = _summarize_n8n_freshness(last_ping_at=last, now=NOW)
+    assert out["status"] == "dead"
+    assert out["seconds_since_last_ping"] == 24 * 3600
+
+
+# ---------------------------------------------------------------------------
+# Constants sanity (catches accidental tuning regressions)
+# ---------------------------------------------------------------------------
+def test_thresholds_are_ordered():
+    """Healthy window must be smaller than stale window, otherwise the
+    classification logic short-circuits to 'healthy' for everything."""
+    assert N8N_HEALTHY_WITHIN_SECONDS < N8N_STALE_WITHIN_SECONDS
+
+
+def test_stuck_threshold_is_above_normal_turn_time():
+    """STUCK_AFTER_SECONDS must be comfortably greater than a normal turn
+    duration. With the new debounce: poll 2s + max-wait 15s + LLM ~3s + DB ~1s
+    ≈ 21s ceiling. 60s is the absolute minimum; we use 120s for headroom."""
+    assert STUCK_AFTER_SECONDS >= 60
+
+
+def test_n8n_ping_entity_id_is_fixed():
+    """The sentinel must be stable across deploys; otherwise queries that
+    'WHERE entity_id = N8N_PING_ENTITY_ID' break."""
+    import uuid
+    assert N8N_PING_ENTITY_ID == uuid.UUID("00000000-0000-0000-0000-000000000031")


### PR DESCRIPTION
## Summary

Closes the visibility gap on n8n integration. Today, if the `cafe_arenillo_v2` subworkflow stops firing (broken trigger, container down, ID changed), the only signal is customer messages going unanswered. This PR adds two endpoints that make the failure observable from the backend:

- **`POST /api/v1/internal/n8n-ping`** — heartbeat from n8n, written to `audit_log` with `event_type='n8n_ping'`.
- **`GET /api/v1/internal/integration-health`** — returns n8n freshness + count of stuck conversations.

Stuck conversation = state in (active, human_handoff) AND latest message is inbound AND created > 120s ago. That's the strongest signal (customers actually waiting); the n8n ping is supplementary.

## Why audit_log and not a new table

Per the May-2 review: audit_log already has the right shape (event_type + entity_id + jsonb payload), and we agreed in the planning thread to avoid table proliferation. Migration 010 adds the supporting index:
```sql
CREATE INDEX ix_audit_log_event_created ON audit_log (event_type, created_at DESC);
```
Keeps the freshness query O(1) regardless of how much audit_log grows.

## Multi-tenant

Both endpoints require `X-Client-ID` and scope all queries to that client. When more tenants come online, the same master n8n workflow can ping with different client_ids.

## Response shape

`GET /api/v1/internal/integration-health` returns:
```json
{
  "n8n": {
    "status": "healthy",
    "last_ping_at": "2026-05-03T12:00:00+00:00",
    "seconds_since_last_ping": 30
  },
  "stuck_conversations": {
    "count": 2,
    "examples": [
      {"conversation_id": "...", "last_inbound_at": "...", "minutes_pending": 5}
    ]
  },
  "checked_at": "2026-05-03T12:00:30+00:00"
}
```

Status thresholds (tunable in `services/integration_health.py`):
- `healthy`: < 180s since last ping
- `stale`: 180–600s
- `dead`: > 600s
- `unknown`: no ping recorded ever

## What is NOT in this PR (scoped out)

The n8n-side workflow that POSTs `/n8n-ping` every 60s. After this backend deploys, I'll wire it via the n8n public API as a follow-up commit on this branch (or a separate PR if simpler). The wiring needs:
- A new Schedule Trigger workflow in n8n
- HTTP Request node POSTing to `/api/v1/internal/n8n-ping` with auth headers
- Body: `{"workflow_name": "cafe_arenillo_v2", "execution_id": "{{ $execution.id }}"}`
- `X-Client-ID: 00000000-0000-0000-0000-000000000001` (Café Arenillo)

Until that workflow exists, the `n8n.status` will read `unknown` and the stuck-conversations check still works as a standalone signal.

## Test plan

- [x] `pytest tests/ -v` — 140/140 green (10 new tests cover the freshness classification function and constant-ordering invariants)
- [ ] Apply migration 010 to staging
- [ ] Verify `POST /api/v1/internal/n8n-ping` returns `{recorded: true}` and creates an audit_log row
- [ ] Verify `GET /api/v1/internal/integration-health` returns the snapshot with `unknown` initially, then `healthy` after the first ping
- [ ] (Manual) After deploy, wire the n8n schedule + verify status transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)