### PR TITLE
Migration 010: rename client 'Café Demo' → 'Café Arenillo'

### DIFF
--- a/migrations/versions/010_rename_client_cafe_arenillo.sql
+++ b/migrations/versions/010_rename_client_cafe_arenillo.sql
@@ -1,0 +1,21 @@
+-- Migration 010: Rename client 'Café Demo' → 'Café Arenillo'
+--
+-- The initial seed (001_initial_schema.sql:303) set clients.name = 'Café Demo'.
+-- Migration 003 renamed the product to 'Café Arenillo' and wrote the
+-- system_prompt with the real business name, but clients.name was never
+-- updated — leaving an internal label out of sync with the rest of the system
+-- (product catalog, system_prompt, docs all say "Café Arenillo").
+--
+-- This normalizes clients.name. The slug ('cafe-demo') is intentionally LEFT
+-- UNCHANGED: it is a stable identifier that may be referenced by routing or
+-- external lookups, and renaming it carries breakage risk that a display-name
+-- fix does not warrant.
+--
+-- No schema change. Idempotent: the WHERE guard makes a re-run a no-op.
+--
+-- Applied: (pending)
+
+UPDATE clients
+   SET name = 'Café Arenillo'
+ WHERE id = '00000000-0000-0000-0000-000000000001'
+   AND name = 'Café Demo';


### PR DESCRIPTION
## Qué
Migración 010: `UPDATE clients SET name = 'Café Arenillo'` para el cliente seed (`...0001`). El seed original (001:303) sembró `'Café Demo'` y nunca se actualizó, dejando la etiqueta interna desincronizada del resto del sistema (producto, system_prompt, docs ya dicen "Café Arenillo").

## Alcance
- Solo `clients.name`. El `slug` (`cafe-demo`) se deja intacto a propósito (identificador estable, posibles referencias de routing/lookup).
- Idempotente (guard en el WHERE). Sin cambio de schema.

## Aplicación a prod
Las migraciones se aplican **manualmente** (convención `-- Applied:`). Mergear esto sincroniza el repo; prod se sincroniza cuando se corra la 010 contra la DB de prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)