### PR TITLE
docs(010): mark migration as applied to prod

### DIFF
--- a/migrations/versions/010_rename_client_cafe_arenillo.sql
+++ b/migrations/versions/010_rename_client_cafe_arenillo.sql
@@ -13,7 +13,7 @@
 --
 -- No schema change. Idempotent: the WHERE guard makes a re-run a no-op.
 --
--- Applied: (pending)
+-- Applied: 2026-06-16 (prod, manually via psql)
 
 UPDATE clients
    SET name = 'Café Arenillo'


### PR DESCRIPTION
## Qué
Cambio de **una línea** en `migrations/versions/010_rename_client_cafe_arenillo.sql`: el comentario `-- Applied:` pasa de `(pending)` a `2026-06-16 (prod, manually via psql)`.

## Por qué
La migración 010 ya se aplicó a la prod DB el 2026-06-16 (`clients.name` 'Café Demo' → 'Café Arenillo', verificado antes/después). El comentario quedó desfasado porque la corrección de fecha original cayó en un commit que no entró al merge de #45. El statement `UPDATE` no cambia.

Sin impacto funcional ni de schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)