### PR TITLE
docs: add north-star and session briefs (audit + impl P2/P4)

### DIFF
--- a/sales-ai-docs/docs/architecture/north-star.md
+++ b/sales-ai-docs/docs/architecture/north-star.md
@@ -1,0 +1,109 @@
+# Norte conceptual — hacia dónde apuntamos (NO implementar todavía)
+
+> **Qué es esto**: contexto de DIRECCIÓN para entender hacia dónde queremos llevar el
+> Sales AI Agent. Son ideas validadas externamente por un accelerator de Databricks
+> (banking-agent-accelerator) que llegó de forma independiente a la misma tesis que
+> nosotros.
+>
+> **Qué NO es esto**: un plan de implementación. NADA de este archivo se construye
+> ahora. Estamos en fase de **entender el estado actual** (ver `docs/audit-brief.md`).
+> Este archivo existe para que, al auditar, se entienda el norte — y opcionalmente se
+> note qué tan lejos/cerca está el código actual de él, SIN cambiarlo.
+>
+> **Regla para Claude Code**: tratar este archivo como solo-lectura-de-contexto. No
+> implementar, no refactorizar hacia esto, no crear migraciones. Si al auditar notas
+> brechas respecto a este norte, repórtalas como observación, no como tarea.
+
+---
+
+## La tesis que ya compartimos (validación, no novedad)
+
+Un equipo de Databricks construyó un "Deterministic Stateful Agent with Async
+Human-in-the-Loop" para banca, y llegó a la MISMA frontera que nosotros:
+
+- el LLM hace SOLO lenguaje (clasificar intención, extraer campos, redactar)
+- una máquina determinista controla TODO el flujo (el routing nunca lo decide el LLM)
+- Postgres es el checkpoint persistente / fuente de verdad
+- el human-in-the-loop es ciudadano de primera clase
+
+Esto es palabra por palabra nuestro "el LLM conversa, el backend gobierna" (ADR-001,
+ADR-002). La conclusión importante: **nuestra arquitectura está validada de forma
+independiente.** No necesitamos rediseñarla. El norte es endurecer uniones, no
+reconstruir.
+
+---
+
+## Las 3 ideas del accelerator que SÍ queremos adoptar (a futuro)
+
+### 1. Resume asíncrono basado en checkpoint (la más valiosa)
+
+**Qué hacen ellos**: cuando un paso lento bloquea (un background check), el grafo se
+PAUSA en un estado de espera explícito (`WAITING_FOR_BACKGROUND_CHECK`), sale a END, y
+NO mantiene nada abierto. El resultado entra después por un endpoint que escribe el
+checkpoint en Postgres (`graph.aupdate_state(...)`) y **retorna sin llamar al LLM**.
+El siguiente mensaje del usuario reanuda transparentemente.
+
+**Por qué nos importa**: ataca de raíz nuestro riesgo #1 — contexto viejo entre Call 1
+y Call 2 (ADR-003). Hoy lo mitigamos REACTIVAMENTE con `strategy_version` (409 si
+stale). El patrón de ellos es estructuralmente inmune: no hay ventana sostenida por una
+llamada en vuelo; el estado se materializa en el checkpoint y cualquier actor (usuario,
+operador, sistema externo) converge sobre la misma verdad sin coordinación temporal
+frágil.
+
+**Cómo encaja en lo nuestro**: nuestro `human_handoff` (hoy casi terminal) se
+convertiría en un estado de espera con resume por checkpoint, análogo a su
+`WAITING_FOR_BACKGROUND_CHECK`. Mantendríamos `strategy_version` como red de seguridad,
+pero dejaríamos de depender de que Call 1 y Call 2 estén "cerca" en el tiempo. Encaja
+especialmente bien porque WhatsApp YA es turn-based y desconectado — el modelo
+"pausar y reanudar en el siguiente mensaje" le queda natural.
+
+> Esto, si se decide, sería su propio ADR. NO ahora.
+
+### 2. Modo `llm=None` — el grafo entero corre sin LLM (objetivo de testeo)
+
+**Qué hacen ellos**: `build_graph(llm=None)` corre el grafo COMPLETO con stubs
+deterministas, sin red, sin API key, sin costo. Sus smoke tests ejercen el flujo
+entero así.
+
+**Por qué nos importa**: es exactamente lo que nos falta (DEUDA #1: cero tests de
+integración). Hoy tenemos tests del DAG aislado; el norte es un motor end-to-end
+ejecutable sin LLM, donde la clasificación de intención y la extracción de campos
+tengan stubs deterministas (substring/regex/`key=value`) como fallback. Eso da tests
+de la máquina completa (ingest → estrategia → validación → side effects) sin costo.
+
+### 3. Escenarios de error como DATOS, no como ramas ad-hoc
+
+**Qué hacen ellos**: cada stub recibe un `stub_scenario` (`happy_path`,
+`ambiguous_email`, `send_failure`, `low_confidence`, `missing_fields`...). Forzar un
+camino de error es pasar un dato, no escribir una rama especial.
+
+**Por qué nos importa**: nosotros tenemos los equivalentes latentes (producto inválido
+→ line item omitido, confirmación faltante → campos bloqueantes, gate rechaza slot).
+El norte es CATALOGAR esos escenarios como datos de prueba, para ejercer cada rama de
+error sin mocks. Endurece nuestra explicabilidad propuesta/aprobación.
+
+---
+
+## Lo que NO copiamos (diferencias deliberadas, ya decididas)
+
+Para que Code no confunda "validado" con "idéntico":
+
+- **NO migramos a LangGraph.** Ellos usan ese framework; nosotros tenemos nuestro
+  two-call pattern sobre n8n (ADR-002) y nuestro DAG propio. Robamos el *vocabulario*
+  de estado explícito, no el runtime. Nuestro DAG de dependencias no lineales
+  (`blocked_by`) es más expresivo que su flujo lineal con re-ask.
+- **Nuestro multi-tenant es real** (`client_id` en cada tabla, `business_rules` por
+  cliente). El accelerator es single-tenant con stubs sintéticos. Aquí estamos
+  ADELANTE, no atrás.
+- **Nuestro canal es WhatsApp asíncrono** (vía Chakra), no web con streaming. Esto
+  refuerza el punto 1: el resume por checkpoint encaja MEJOR en nuestro canal que en
+  el de ellos.
+
+---
+
+## Resumen del norte en una frase
+
+La arquitectura está validada; el trabajo a futuro es **endurecer las uniones
+críticas** (resume por checkpoint en vez de solo `strategy_version` defensivo),
+**poder testear el motor completo sin LLM**, y **catalogar los escenarios de error
+como datos**. Todo aditivo, nada de rediseño. Pero primero: entender el estado actual.

--- a/sales-ai-docs/docs/briefs/audit-brief.md
+++ b/sales-ai-docs/docs/briefs/audit-brief.md
@@ -1,0 +1,163 @@
+# Brief de auditoría v2 — estado actual + revisión viva + plan de trabajo (READ-ONLY)
+
+> **Propósito**: cerrar lo que la auditoría de archivos NO pudo ver (la Postgres
+> viva y el n8n desplegado), reconfirmar hallazgos clave contra el sistema real, y
+> producir un **plan de trabajo priorizado para arreglar lo que está roto**,
+> secuenciado de forma coherente con el north star. NO es un brief de
+> implementación: este pase sigue siendo de diagnóstico + planeación, no de ejecución.
+>
+> ## Reglas absolutas de esta sesión (salvaguarda de PRODUCCIÓN)
+>
+> - **READ-ONLY contra todo sistema vivo.** La conexión a Postgres debe ser de solo
+>   lectura. PROHIBIDO: `INSERT`, `UPDATE`, `DELETE`, `ALTER`, `DROP`, `CREATE`,
+>   `TRUNCATE`, correr migraciones, o cualquier DDL/DML. Solo `SELECT` (y `EXPLAIN`,
+>   `\d`, lectura de catálogo).
+> - **NO tocar el n8n vivo** más allá de LEER la definición del workflow activo.
+>   Prohibido activar/desactivar workflows, editar nodos, ejecutar el workflow.
+> - **NO editar, crear ni borrar archivos** del repo. NO "arreglar de paso".
+> - Si una consulta o paso pudiera mutar estado, NO lo ejecutes: descríbelo y
+>   reporta que lo omitiste por la regla de solo-lectura.
+> - Toda PII (teléfono, dirección, email, nombre) **enmascarada** en el reporte.
+> - Cada hallazgo con evidencia: `archivo:línea`, la query `SELECT` exacta, o el
+>   nombre del nodo de n8n. Si algo no es determinable, decir "no determinable",
+>   no adivinar.
+>
+> **Entregable**: un reporte en prosa (no escribir a disco; lo guarda el humano).
+> Secciones 0–5 = re-verificación; 6–7 = revisión viva nueva; 8 = plan de trabajo.
+
+---
+
+## Contexto que ya sabemos (de la auditoría de archivos previa)
+
+No re-derives esto desde cero; pártelo como base y VERIFÍCALO contra el sistema vivo:
+
+- El workflow **v2 (backend-governed) es el que corre** en producción para Café
+  Arenillo (confirmado por el humano). El legacy `cafe_arenillo.json` NO es el activo.
+  → Confirma esto LEYENDO el n8n vivo (sección 7), no asumiéndolo.
+- El backend hace ≥2 transacciones en ingest (no "1" como dice el doc), con un
+  `commit()` intermedio + `asyncio.sleep(5)` que suelta el advisory lock.
+- El "reset por idle 30 min" (DEUDA #10) NO existe en código.
+- `quantity`/`grind_preference` se piden en el prompt pero se filtran fuera de
+  `STRATEGY_FIELDS` → no se persisten.
+- Gate de `payment_confirmation`: `merged` se calcula una sola vez → un
+  `user_confirmation` rechazado en el mismo turno puede colarse.
+- Outbound (texto e imagen) SIN idempotencia desde que 007 dropeó `idempotency_key`.
+  La imagen duplicada es un síntoma de esto.
+- La lazy-compaction / resume entre conversaciones YA existe en código sin ADR.
+
+---
+
+## Secciones 0–5: re-verificación rápida contra el sistema vivo
+
+(Estas ya se auditaron sobre archivos. Aquí solo CONFIRMA o REFUTA contra datos/n8n
+vivos lo que antes era "no determinable". No repitas el análisis de archivos completo.)
+
+**0. Drift** — ¿algún drift nuevo aparece al comparar el schema REAL de la DB
+(catálogo de Postgres) contra las migraciones del repo? ¿La última migración aplicada
+en la DB coincide con la última del repo? (query a la tabla de versiones de migración
+si existe, o `\dt` + inspección de columnas).
+
+**1–5** — solo reconfirma los puntos que dependían de datos vivos:
+- shape real de `extracted_context` y `profile` (sección 6 lo cubre en detalle),
+- qué modelo y qué prompt recibe de verdad el LLM en el workflow activo (sección 7),
+- si hay evidencia en datos de pérdida de contexto por la ventana de 24h.
+
+---
+
+## 6. Revisión de la base de datos Postgres VIVA (solo SELECT)
+
+Objetivo: cerrar los "no determinable" del primer reporte y validar que el schema y
+los datos reales coinciden con lo que el código asume.
+
+- **Inventario real**: lista las tablas que EXISTEN en la DB (`\dt`). ¿Son las 7
+  activas que el doc afirma (post-007)? ¿Sobrevive alguna tabla supuestamente
+  dropeada (`leads`, `orders`, `order_line_items`)? ¿Existe alguna tabla que el repo
+  no documenta?
+- **Schema vs. migraciones**: para cada tabla activa, ¿las columnas, tipos y CHECK
+  constraints reales coinciden con la última migración del repo? Reporta diferencias.
+- **Shape real del JSONB** (el "no determinable" clave): consulta una muestra pequeña
+  (5–10 filas, PII enmascarada) de `conversations.extracted_context` y
+  `client_users.profile`. ¿Qué claves aparecen de verdad? ¿Aparece `quantity` /
+  `grind_preference` en algún `extracted_context` real (lo que confirmaría o
+  refutaría que el filtro los descarta siempre)? ¿El `profile` tiene `purchases` con
+  `quantity`/`total`, o llega incompleto como predice el bug?
+- **Integridad multi-tenant en datos**: ¿hay alguna fila con `client_id` nulo o
+  inconsistente en tablas tenant-facing? ¿Algún `conversation`/`message` huérfano?
+- **Idempotencia en datos**: ¿hay mensajes outbound duplicados reales? (p.ej. dos
+  filas en `messages` con `direction='outbound'`, mismo `conversation_id`, mismo
+  contenido/imagen, timestamps cercanos). Esto CONFIRMARÍA el bug de imagen con
+  evidencia dura, no solo por código.
+- **Estados en uso**: `SELECT state, COUNT(*) FROM conversations GROUP BY state`.
+  ¿Se usan de verdad solo los 3 estados (active/human_handoff/closed)?
+- **Salud operativa básica**: volumen de filas por tabla, conversaciones activas,
+  cuántas escalaron a `human_handoff` sin resolver. Sin tocar nada, solo contar.
+
+> Recordatorio: solo `SELECT`. Si para responder algo necesitarías escribir, repórtalo
+> como "requiere escritura, omitido".
+
+## 7. Revisión del flujo n8n VIVO (solo lectura de la definición)
+
+Objetivo: cerrar el hallazgo 0.1 del primer reporte con evidencia del workflow activo,
+y rastrear el camino real de la imagen.
+
+- **Cuál corre**: confirma cuál workflow está `active: true` en el n8n vivo y si de
+  verdad llama a `/ingest/message` y `/agent/action`. Pega los nombres de los nodos
+  HTTP y sus URLs (enmascara hosts/tokens).
+- **Ensamble del prompt**: identifica el nodo donde se concatena el system prompt
+  final (el "Build prompt context" o equivalente). ¿Qué piezas mete y en qué orden?
+  Reconstruye el prompt final REAL que se manda al LLM (con las piezas del backend),
+  no el teórico.
+- **Modelo real**: ¿qué modelo usa el nodo del LLM en el workflow activo
+  (gpt-4o-mini, gpt-4.1-mini, otro)? Esto resuelve la discrepancia del primer reporte.
+- **Camino de la imagen** (causa raíz del bug, con evidencia de n8n): localiza el/los
+  nodo(s) que envían media a Chakra. ¿Cuántos caminos pueden disparar un envío de
+  imagen en un mismo turno? ¿El texto y la imagen son ramas separadas que podrían
+  ejecutarse ambas? ¿Hay reintentos configurados en ese nodo sin idempotencia?
+  Cruza esto con la evidencia de duplicados en datos (sección 6).
+- **Manejo del 409 (strategy_version stale)**: ¿n8n maneja el 409 de `/agent/action`?
+  ¿Reintenta el ingest, o falla silenciosamente? (ADR-003 depende de esto; si n8n no
+  lo maneja, la protección de contexto viejo no sirve en la práctica).
+- **Fallas silenciosas**: ¿hay manejo de error / alerta si el backend responde 5xx o
+  no responde? (DEUDA #3). Solo reportar si existe o no, no arreglar.
+
+## 8. Plan de trabajo — priorizado, secuenciado por el north star
+
+Con TODO lo anterior (archivos + DB viva + n8n vivo), produce un plan de trabajo para
+**arreglar y ordenar lo que está roto o desalineado**. Reglas para el plan:
+
+- **Es un plan de remediación, no de construcción de features nuevas.** Ordena los
+  fixes de bugs reales y la sincronización de drift. NO incluyas como tareas las ideas
+  del north star (resume asíncrono, llm=None, escenarios-como-datos) — esas NO se
+  implementan en esta fase.
+- **El north star entra como LENTE DE SECUENCIACIÓN, no como backlog.** Para cada fix,
+  pregunta: "¿este arreglo es coherente con hacia dónde vamos, o crea algo que después
+  habrá que deshacer?". Ejemplo: el fix de la imagen debe hacerse como un caso del
+  problema general de *idempotencia outbound* (alineado con el north star idea #1 de
+  estado materializado), NO como un parche especial solo-para-imagen. Marca para cada
+  fix si está "alineado / neutro / en tensión" con el north star, y por qué.
+- **Clasifica cada ítem por costo y riesgo**:
+  - 🟢 Texto puro / config (drift de docs): barato, reversible, sin riesgo de prod.
+  - 🟡 Código acotado con test (bugs de datos sin tocar schema).
+  - 🔴 Toca schema, auth, o el hot path: requiere su propio ADR ANTES de tocar nada.
+- **Ordena por**: (1) lo que desbloquea o protege producción primero, (2) costo
+  ascendente dentro del mismo nivel de riesgo, (3) dependencias (qué fix habilita cuál).
+- **Para cada ítem del plan**, da: qué se arregla, evidencia (archivo:línea / query /
+  nodo), tipo (🟢/🟡/🔴), alineación con north star, y si necesita ADR previo.
+- **Marca explícitamente qué requiere un ADR** antes de ejecutarse (mínimo esperado:
+  idempotencia outbound). NO escribas el ADR aquí; solo señala que hace falta.
+
+El plan debe terminar con una **secuencia recomendada de sesiones de Code**: qué hacer
+en la primera sesión (lo 🟢 de cero riesgo), qué en la segunda (🟡 con tests), y qué
+queda bloqueado tras decisión de ADR (🔴). Una cosa a la vez, con commit y verificación
+entre cada una.
+
+---
+
+## Cómo reportar
+
+Evidencia siempre (archivo:línea, query SELECT, o nodo de n8n). PII enmascarada.
+Distingue lo confirmado contra el sistema vivo de lo inferido desde archivos. Donde el
+sistema vivo CONTRADIGA al primer reporte, dilo explícitamente — el sistema vivo gana.
+
+Este pase termina en un PLAN, no en cambios. La ejecución es una sesión posterior,
+fix por fix, con la regla de "entender y decidir antes de tocar" intacta.

--- a/sales-ai-docs/docs/briefs/impl-brief-P2-P4.md
+++ b/sales-ai-docs/docs/briefs/impl-brief-P2-P4.md
@@ -1,0 +1,103 @@
+# Brief de implementación — Sesión P2 + P4 (cercanía por datos)
+
+> **Esto NO es una sesión de auditoría.** Esta sesión SÍ escribe código en el repo.
+> Pero NO toca sistemas vivos (ni Postgres de prod ni n8n vivo) salvo para
+> diagnóstico de solo-lectura explícitamente marcado. El despliegue a prod es un paso
+> posterior y separado, no parte de esta sesión.
+>
+> **Disciplina baby-steps (innegociable)**: una cosa a la vez. Cada cambio se
+> implementa, se cubre con test, se corre la suite en verde, y se commitea ANTES de
+> empezar el siguiente. NO encadenar P2 y P4 en un solo commit. Si un test queda
+> rojo, se arregla o se revierte ese paso — no se avanza con deuda roja.
+>
+> **Orden fijo**: P2 (fix) primero. P4 (diagnóstico) después. P2 desbloquea P4.
+>
+> **Antes de tocar nada**: dame tu plan de cambios por archivo y espera mi
+> confirmación. No quiero ver código hasta aprobar el plan.
+
+---
+
+## Contexto (de la auditoría viva, ya confirmado en datos)
+
+- El LLM extrae `quantity` (12 msgs) y `grind_preference` (8 msgs), pero
+  `STRATEGY_FIELDS` (agent_action.py:35-39) los descarta antes del merge a
+  `extracted_context`. El bloque "ESTADO DEL PEDIDO" los vuelve a pedir cada turno
+  (prompt_context.py:111-121, _ORDER_FIELDS). Efecto: el bot re-pregunta lo ya dicho.
+- `client_users.profile` está VACÍO en prod: nunca se poblaron `purchases`,
+  `last_conversation_summary`, etc. La lazy-compaction (ingest.py:146-167 /
+  conversation_summary.py) falla en silencio: traga la excepción y devuelve None con
+  un warning que nadie lee (conversation_summary.py:210-215).
+- La key de OpenAI SÍ carga al boot (no es esa la causa). Causa exacta del fallo de
+  compaction: aún no determinada.
+
+---
+
+## P2 — Persistir quantity / grind_preference / roast_preference (FIX)
+
+**Objetivo**: que los datos que el cliente ya dio se guarden y dejen de re-pedirse.
+
+**Diseño a confirmar conmigo antes de codear**: estos campos NO son del DAG (no son
+checkpoints de cierre de venta), así que NO deben entrar a `STRATEGY_FIELDS` sin más
+—eso podría alterar la lógica del DAG—. La opción más limpia es un set separado de
+"order fields" no-DAG que también se mergea a `extracted_context`, en paralelo a
+`STRATEGY_FIELDS`, sin que el GoalStrategyEngine los trate como checkpoints. Propón la
+forma concreta (constante separada, merge explícito) y espera visto bueno.
+
+**Alcance del cambio**:
+- Persistir `quantity`, `grind_preference`, `roast_preference` a `extracted_context`
+  cuando el LLM los extrae (agent_action.py, zona del filtro :35-39 y merge).
+- Completar `_merge_profile` para que el registro de `purchases` lleve `quantity` y
+  `total` como promete el COMMENT de 008:50-64 (hoy agent_action.py:301-304 guarda
+  solo {date, product_id}).
+- Verificar que `prompt_context.py` (ESTADO DEL PEDIDO) deje de marcar como faltante
+  lo que ya está en contexto.
+
+**Tests obligatorios (servicio, pure-python, sin DB viva)**:
+- Dado extracted_data con `quantity` → se persiste en extracted_context.
+- Dado un pedido con quantity+product → el registro de purchase lleva quantity y total.
+- Regresión: que esto NO altere la evaluación del DAG ni los checkpoints existentes
+  (correr los ~22 tests de goal_strategy en verde).
+
+**NO toca schema** (JSONB flexible). NO requiere ADR. NO requiere migración.
+
+**Commit P2 y verde antes de pasar a P4.**
+
+---
+
+## P4 — Diagnosticar la lazy-compaction rota (DIAGNÓSTICO, no fix aún)
+
+**Objetivo de esta sesión**: SABER por qué falla. NO arreglarla a ciegas.
+
+**Pasos**:
+1. Reproducir `summarize_conversation` en entorno controlado (local / test), contra
+   el shape de datos de la conversación del 3-may (4 msgs) o un fixture equivalente.
+   Capturar la excepción real que hoy se traga el try/except
+   (conversation_summary.py:210-215). Reportarla — no silenciarla.
+2. Mínimo entregable de fix permitido en esta sesión: subir ese `logger.warning`
+   silencioso a algo observable (logger.error + contador / métrica), para que la
+   memoria del negocio deje de morir en silencio (DEUDA #3). Esto es 🟢 y seguro.
+3. Si el paso 1 revela la causa raíz y el fix es acotado y de bajo riesgo, PROPONLO
+   —con su clasificación 🟢/🟡— pero NO lo implementes sin confirmármelo. Si la causa
+   resulta tocar el hot path o schema, se detiene y va a decisión separada.
+
+**Diagnóstico de solo-lectura contra prod permitido SOLO si es necesario**: un SELECT
+puntual para inspeccionar el shape exacto de la conversación del 3-may. Read-only,
+PII enmascarada, misma regla que la auditoría. Nada de escribir.
+
+**Dependencia explícita**: P4 se prueba DESPUÉS de P2, porque un resumen útil necesita
+que quantity/preferencias ya estén en contexto. Verificar que, con P2 aplicado, un
+resumen reconstruido incluiría el pedido completo.
+
+---
+
+## Cierre de la sesión
+
+- Dos commits limpios: uno P2 (fix + tests), uno P4 (observabilidad del warning +
+  reporte de causa raíz). Si P4 produce además un fix aprobado, va en su propio commit.
+- NO desplegar a prod en esta sesión. El deploy es un paso posterior, deliberado.
+- Reportar: qué se cambió, qué tests se añadieron, la causa raíz de la compaction (o
+  "aún no concluyente" con lo que se encontró), y qué queda pendiente.
+- Recordatorio de carriles: esto es remediación. NO implementar nada del north-star
+  (resume asíncrono, sale_events, ADR-009 de memoria de relación) — esas siguen en
+  pausa. Si al tocar el perfil te dan ganas de "ya que estoy" construir la memoria de
+  relación, NO: ese es otro carril y necesita su propia decisión.


### PR DESCRIPTION
## Qué
Versiona tres documentos que vivían en local sin pushear:

- `sales-ai-docs/docs/architecture/north-star.md` — visión de arquitectura de referencia (5.7K)
- `sales-ai-docs/docs/briefs/audit-brief.md` — brief de la sesión de auditoría (9.9K)
- `sales-ai-docs/docs/briefs/impl-brief-P2-P4.md` — brief ejecutado en la sesión de P2 + P4 (5.6K)

## Por qué
Quedaron sin commitear; con esto main refleja el material que ya estaba en uso.

## Alcance
Solo documentación. Sin código ni schema. Tres archivos nuevos, sin ediciones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)