### PR TITLE
fix(agent-action): close permeable payment_confirmation gate (P3)

### DIFF
--- a/sales_agent_api/app/services/agent_action.py
+++ b/sales_agent_api/app/services/agent_action.py
@@ -101,16 +101,23 @@ def compute_context_updates(
     """
     order_updates = {k: v for k, v in extracted_data.items() if k in ORDER_FIELDS and v}
     strategy_updates = {k: v for k, v in extracted_data.items() if k in STRATEGY_FIELDS and v}
-    merged = {**current_context, **order_updates, **strategy_updates}
     rejections: list[dict] = []
 
     # user_confirmation requires full_name + phone + shipping_address + shipping_city
+    merged = {**current_context, **order_updates, **strategy_updates}
     if "user_confirmation" in strategy_updates:
         missing = [f for f in _USER_CONFIRMATION_REQUIRES if not merged.get(f)]
         if missing:
             del strategy_updates["user_confirmation"]
             rejections.append({"field": "user_confirmation", "missing": missing})
-    # payment_confirmation requires user_confirmation + phone + shipping_address
+
+    # payment_confirmation requires user_confirmation + phone + shipping_address.
+    # Recompute merged AFTER the user_confirmation gate: a user_confirmation that
+    # was rejected THIS turn has just been dropped from strategy_updates, so it
+    # must not count toward payment's prerequisite. (A user_confirmation already
+    # persisted in current_context from a prior turn still counts — it survives
+    # in merged via the current_context spread.)
+    merged = {**current_context, **order_updates, **strategy_updates}
     if "payment_confirmation" in strategy_updates:
         missing = [f for f in _PAYMENT_CONFIRMATION_REQUIRES if not merged.get(f)]
         if missing:
@@ -209,6 +216,14 @@ async def process_agent_action(
             if rej["field"] == "user_confirmation":
                 side_effects.append(
                     f"warning:premature_summary_missing_{'+'.join(rej['missing'])}"
+                )
+            # Likewise surface a premature payment_confirmation. This is the money
+            # step, and the human who inherits the handoff must SEE that a payment
+            # was attempted and rejected rather than have it vanish silently. Kept
+            # as a distinct string from the summary warning above.
+            elif rej["field"] == "payment_confirmation":
+                side_effects.append(
+                    f"warning:premature_payment_missing_{'+'.join(rej['missing'])}"
                 )
         if accepted:
             new_context = {**(conversation.extracted_context or {}), **accepted}

--- a/tests/services/test_agent_action.py
+++ b/tests/services/test_agent_action.py
@@ -150,6 +150,89 @@ def test_order_field_does_not_satisfy_a_gate():
 
 
 # ---------------------------------------------------------------------------
+# P3 — payment gate must not be permeable to a same-turn rejected confirmation
+# ---------------------------------------------------------------------------
+def test_payment_does_not_sneak_through_when_user_confirmation_rejected_same_turn():
+    """The P3 bug: in ONE turn the LLM sends user_confirmation=true AND
+    payment_confirmation=true, but full_name is missing. user_confirmation is
+    rejected for the missing name; payment_confirmation must NOT pass on the back
+    of a confirmation that did not survive this turn."""
+    ctx = {
+        # full_name deliberately absent
+        "phone": "3001234567",
+        "shipping_address": "Cra 1 # 2-3",
+        "shipping_city": "Manizales",
+    }
+    accepted, strategy_accepted, rejections = compute_context_updates(
+        {"user_confirmation": "sí", "payment_confirmation": "comprobante.jpg"}, ctx
+    )
+    assert "user_confirmation" not in accepted
+    assert "payment_confirmation" not in accepted
+    assert "payment_confirmation" not in strategy_accepted
+    assert {r["field"] for r in rejections} == {
+        "user_confirmation",
+        "payment_confirmation",
+    }
+    # payment was rejected specifically because user_confirmation is now absent
+    payment_rej = next(r for r in rejections if r["field"] == "payment_confirmation")
+    assert "user_confirmation" in payment_rej["missing"]
+
+
+def test_payment_passes_when_user_confirmation_came_from_prior_turn():
+    """Regression: a user_confirmation already persisted in a PREVIOUS turn still
+    satisfies payment's prerequisite. Only the same-turn rejected case is blocked —
+    the legitimate payment flow must keep working."""
+    ctx = {
+        "user_confirmation": "sí",  # accepted in a prior turn
+        "phone": "3001234567",
+        "shipping_address": "Cra 1 # 2-3",
+    }
+    accepted, strategy_accepted, rejections = compute_context_updates(
+        {"payment_confirmation": "comprobante.jpg"}, ctx
+    )
+    assert accepted.get("payment_confirmation") == "comprobante.jpg"
+    assert strategy_accepted.get("payment_confirmation") == "comprobante.jpg"
+    assert rejections == []
+
+
+def test_payment_passes_when_user_confirmation_valid_same_turn():
+    """When user_confirmation IS valid this turn (all prereqs present) it survives
+    the gate and stays in merged, so a same-turn payment_confirmation still passes.
+    The P3 recompute must not strip an ACCEPTED confirmation."""
+    ctx = {
+        "full_name": "Ana Ruiz",
+        "phone": "3001234567",
+        "shipping_address": "Cra 1 # 2-3",
+        "shipping_city": "Manizales",
+    }
+    accepted, _, rejections = compute_context_updates(
+        {"user_confirmation": "sí", "payment_confirmation": "comprobante.jpg"}, ctx
+    )
+    assert accepted.get("user_confirmation") == "sí"
+    assert accepted.get("payment_confirmation") == "comprobante.jpg"
+    assert rejections == []
+
+
+def test_order_fields_persist_even_when_both_gates_reject():
+    """P2 regression under the P3 change: order details persist regardless of the
+    user/payment gates firing in the same turn."""
+    accepted, strategy_accepted, rejections = compute_context_updates(
+        {
+            "quantity": 2,
+            "grind_preference": "molido",
+            "user_confirmation": "sí",
+            "payment_confirmation": "comprobante.jpg",
+        },
+        {},
+    )
+    assert accepted["quantity"] == 2
+    assert accepted["grind_preference"] == "molido"
+    assert "user_confirmation" not in accepted
+    assert "payment_confirmation" not in accepted
+    assert strategy_accepted == {}
+
+
+# ---------------------------------------------------------------------------
 # _coerce_int
 # ---------------------------------------------------------------------------
 def test_coerce_int_handles_int_str_and_garbage():


### PR DESCRIPTION
## Qué

Cierra el gate permeable de `payment_confirmation` en `compute_context_updates` (`agent_action.py`).

**Causa raíz:** `merged` se computaba una sola vez antes de ambos gates. Cuando el gate de `user_confirmation` rechazaba el slot (precondición faltante, p.ej. `full_name`), el `merged` precomputado todavía lo contenía, así que el gate de `payment_confirmation` —que requiere `user_confirmation` presente— lo dejaba pasar. Resultado: se podía marcar pago confirmado sobre una confirmación de usuario que acababa de ser rechazada en el mismo turno. Preventivo (nunca se disparó en prod), pero protege el paso de DINERO y el estado que el humano hereda en el handoff.

## Cambios

- **Fix** (`agent_action.py`, `compute_context_updates`): se recalcula `merged` **después** del gate de `user_confirmation`, justo antes del de `payment_confirmation`. Un `user_confirmation` rechazado este turno ya no cuenta para la precondición de pago. Un `user_confirmation` heredado de `current_context` (turno previo) sí cuenta — flujo legítimo intacto. Reglas de gate byte-idénticas.
- **Observabilidad** (`agent_action.py`, `process_agent_action`): nuevo side-effect `warning:premature_payment_missing_<missing>` para el rechazo de pago. El string de `user_confirmation` queda byte-idéntico. El humano del handoff debe ver el intento de pago rechazado, no que desaparezca en silencio.

## Tests (puros, sin DB)

- `test_payment_does_not_sneak_through_when_user_confirmation_rejected_same_turn` — fija el contrato roto.
- `test_payment_passes_when_user_confirmation_came_from_prior_turn` — caso legítimo (confirmación previa) sigue pasando.
- `test_payment_passes_when_user_confirmation_valid_same_turn` — confirmación válida en el mismo turno → ambos pasan.
- `test_order_fields_persist_even_when_both_gates_reject` — regresión P2.

**Suite:** 84/84 puros en verde.

## Scope

No toca schema, DAG/checkpoints, ADR, migración, n8n, handoff cutoff, Telegram ni deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)