### PR TITLE
feat(agent-action): circuit breaker for conversational loops (P8)

### DIFF
--- a/sales-ai-docs/docs/briefs/impl-brief-P8.md
+++ b/sales-ai-docs/docs/briefs/impl-brief-P8.md
@@ -1,0 +1,115 @@
+# Brief de implementación — P8: circuit breaker para loops conversacionales
+
+> **Sistema REAL (no greenfield)**: backend FastAPI en prod (Azure Container Apps),
+> Postgres 6 tablas post-007, migración 010, P2/P3/P4/ADR-008 mergeados. Este brief
+> edita código vivo. NO rediseña. NO toca schema.
+>
+> **Alcance honesto**: P8 hace la parte BACKEND, determinista y testeable (detectar
+> loop → marcar human_handoff → side_effect). El EFECTO del escalamiento (que el bot
+> deje de responder + que un humano se entere) depende de piezas que NO existen todavía
+> (corte en n8n, notificación Telegram revertida). Ver "Dependencia conocida". P8 tiene
+> valor solo aunque esas no existan: deja de quemar tokens en el loop y registra el
+> evento. Pero NO se vende como "loop resuelto" — es "loop detectado y marcado".
+>
+> **Disciplina**: plan por archivo antes de codear, espera confirmación. Un commit con
+> sus tests, suite verde. Rama nueva desde main: `feat/p8-circuit-breaker`. NO desplegar.
+
+---
+
+## Contexto (evidencia dura de la auditoría)
+
+Caso real capturado: un usuario fuera de contexto provocó **19 respuestas outbound
+idénticas en 29 minutos (70 mensajes), 0% de progreso en el DAG, sin ningún freno**.
+El sistema no tiene protección contra loops conversacionales. Quema tokens, degrada la
+marca, y —crucial— nadie se entera.
+
+No es preventivo teórico (como fue P3): es un fallo que ya ocurrió con un usuario real.
+
+## Decisión de diseño (confirmada)
+
+- **Disparador**: 3 respuestas outbound **consecutivas con texto idéntico** (comparación
+  EXACTA, no difusa) dentro de la misma conversación. Exacta = sin falsos positivos por
+  respuestas legítimamente parecidas; simple de razonar y testear.
+- **Acción al dispararse**: escalar la conversación a `human_handoff` (mismo mecanismo
+  que el cierre de venta) y emitir un side_effect observable
+  (`circuit_breaker:loop_detected`). El bot NO genera una respuesta más en ese turno.
+
+---
+
+## El fix
+
+### Detección
+- En `compute_context_updates` o el tramo de `process_agent_action` que decide el
+  outbound (`agent_action.py`), ANTES de persistir el nuevo outbound: comparar el
+  `final_response_text` que se va a enviar contra los **2 outbounds inmediatamente
+  anteriores** de la misma conversación (leídos de `messages`, `direction='outbound'`,
+  orden por timestamp desc, límite 2).
+- Si los 2 previos + el actual son texto idéntico → es el 3er idéntico consecutivo →
+  DISPARA.
+- PROPÓN cómo lees los 2 previos: lo más limpio es que el caller ya tenga `recent_messages`
+  disponible (el backend los maneja) y filtrar outbounds ahí, sin query nueva. Si hace
+  falta una query, que filtre por `client_id` + `conversation_id` (tenant-safe). Confírmame
+  el approach antes de codear.
+
+### Acción
+- Al disparar: `conversation.state = "human_handoff"` (reusar la transición existente que
+  usa el auto-escalate del DAG — NO inventar una nueva vía; state_machine.py ya valida
+  active→human_handoff).
+- Emitir `side_effects: ["circuit_breaker:loop_detected"]`.
+- El turno NO envía una respuesta nueva idéntica. Definir el retorno: `approved=False` con
+  un `final_response_text` vacío o nulo, de modo que n8n (chequeando should_respond /
+  final_response_text) no mande nada. CONFIRMA conmigo cómo señalizarlo para que n8n no
+  envíe — hoy n8n manda `final_response_text`; si va vacío, ¿n8n lo maneja? (ver
+  dependencia).
+
+### Guardas
+- La comparación es exacta y solo sobre outbounds consecutivos: un cliente que recibe la
+  misma respuesta 3 veces porque el bot está atascado ES el caso objetivo; una respuesta
+  repetida no-consecutiva (con otra en medio) NO dispara.
+- El texto de las respuestas nunca se loguea en claro más de lo que ya se hace; el
+  side_effect lleva el conteo, no el contenido.
+
+NO toca schema. NO toca el DAG (no es un checkpoint nuevo). NO ADR. NO migración.
+
+---
+
+## Tests obligatorios (puros, sin DB) — en `tests/services/test_agent_action.py`
+
+1. **Dispara al 3ro**: 2 outbounds previos idénticos + este turno produce el mismo texto
+   → estado pasa a human_handoff, side_effect `circuit_breaker:loop_detected`, no se envía
+   respuesta nueva.
+2. **No dispara al 2do**: 1 outbound previo idéntico + este igual → NO dispara (solo 2).
+   Sigue en active, responde normal.
+3. **No dispara con no-consecutivos**: outbound A, luego B, luego A otra vez → NO dispara
+   (no son 3 consecutivos idénticos).
+4. **No dispara con texto distinto**: 3 outbounds consecutivos pero con texto diferente →
+   NO dispara (comparación exacta).
+5. **Regresión**: una conversación normal (respuestas variadas) nunca dispara y el flujo
+   de P2/P3/ADR-008 sigue intacto. Suite completa verde (los ~22 de goal_strategy, los de
+   agent_action, language, validation).
+
+---
+
+## Dependencia conocida (registrar, NO implementar aquí)
+
+El escalamiento de P8 solo es EFECTIVO si:
+- **n8n corta la respuesta** cuando la conversación está en `human_handoff` (hoy no
+  verificado; camino nunca ejercido — mismo issue que el handoff de venta). Si n8n no lee
+  el estado, el bot podría seguir respondiendo pese al marcado.
+- **Alguien se entera** del handoff (notificación Telegram fue revertida, no está en main;
+  no hay vista de operador — deuda #4).
+
+P8 marca y frena el desperdicio del lado backend. Cerrar el lazo (n8n + notificación) es
+un paso SEPARADO, compartido con el handoff de venta. Registrar como dependencia; no
+mezclar en este commit.
+
+---
+
+## Definition of done
+
+- Flujo: 3er outbound idéntico consecutivo → detección determinista en backend →
+  human_handoff + side_effect → no se genera respuesta nueva.
+- Tenant isolation: la lectura de outbounds previos filtra por client_id+conversation_id.
+- Sin schema, sin migración, sin dependencias nuevas, sin tocar n8n.
+- Reportar: archivo:línea, tests añadidos, y confirmación explícita de la dependencia n8n
+  (que el corte real de respuesta queda fuera de scope y pendiente).

--- a/sales-ai-docs/docs/briefs/p8-limitaciones-conocidas.md
+++ b/sales-ai-docs/docs/briefs/p8-limitaciones-conocidas.md
@@ -1,0 +1,52 @@
+# P8 — Limitaciones conocidas del circuit breaker (registro)
+
+> Fecha: 2026-07-11. Contexto: P8 (`feat/p8-circuit-breaker`) implementó la parte
+> backend del freno a loops conversacionales: 3 outbounds idénticos consecutivos →
+> `human_handoff` + side_effect `circuit_breaker:loop_detected` + supresión de la
+> respuesta (`approved=False`, `final_response_text=""`). Ver `impl-brief-P8.md`.
+>
+> Estas dos limitaciones quedan registradas JUNTAS y fuera del scope de P8.
+> Ninguna invalida el valor de P8 (deja de quemar tokens y registra el evento),
+> pero ambas impiden vender "loop resuelto".
+
+---
+
+## 1. El corte real de la respuesta depende de n8n (dependencia)
+
+- El backend marca `human_handoff` y devuelve `approved=False` +
+  `final_response_text=""` — pero HOY n8n manda `final_response_text` a Chakra
+  **sin chequear** `approved` ni el estado de la conversación. Camino nunca
+  ejercido (mismo issue que el handoff de cierre de venta).
+- Nadie se entera del handoff: la notificación Telegram fue revertida (no está
+  en main) y no hay vista de operador (deuda #4 en `CLAUDE.md`).
+- **Cerrar el lazo es trabajo separado, compartido con el handoff de venta**:
+  1. n8n debe chequear `approved === true && final_response_text` no vacío
+     antes de enviar (y/o cortar cuando `conversation_state = human_handoff`).
+  2. Notificación a un humano (Telegram u operador) al escalar.
+
+Mientras tanto: el breaker suprime la respuesta también cuando la conversación
+YA está en `human_handoff`, así que aunque n8n siga llamando `/agent/action`,
+el backend no persiste ni aprueba más outbounds idénticos.
+
+## 2. Loop de texto variable NO cubierto (candidato P9)
+
+- El trigger de P8 es comparación **EXACTA** de texto (decisión confirmada del
+  brief: cero falsos positivos por respuestas legítimamente parecidas, simple
+  de razonar y testear).
+- Un loop donde el LLM **parafrasea** — texto distinto cada turno, 0% de
+  progreso en el DAG — NO dispara el breaker.
+- Cubrirlo requiere otro detector (estancamiento del DAG: N turnos consecutivos
+  sin progreso) con una decisión de producto pendiente (¿qué N?) y riesgo real
+  de falsos positivos: conversaciones legítimas pasan turnos sin progreso
+  (preguntas de producto, small talk, "déjame pensarlo").
+- Registrado como **candidato P9**. No mezclar con P8.
+
+---
+
+## Definición de "cerrado"
+
+Este registro se cierra cuando:
+- [ ] n8n corta el envío según `approved`/`final_response_text` (limitación 1)
+- [ ] existe notificación de handoff a un humano (limitación 1)
+- [ ] hay decisión explícita sobre el detector de estancamiento — implementarlo
+      o descartarlo con ADR (limitación 2)

--- a/sales_agent_api/app/services/agent_action.py
+++ b/sales_agent_api/app/services/agent_action.py
@@ -1,6 +1,9 @@
 """Agent action validation service.
 
 After the LLM produces a response, n8n calls this service to:
+  0. Circuit breaker (P8): if the response would be the 3rd consecutive
+     identical outbound, escalate to human_handoff and suppress it
+     (approved=False, empty final_response_text) instead of persisting.
   1. Persist strategy-relevant extracted_data into conversation.extracted_context
      (with DAG gates to enforce data order: user_confirmation needs
      name+phone+address+city; payment_confirmation needs user_confirmation+phone+address)
@@ -80,6 +83,50 @@ class StaleContextError(AgentActionError):
 # share one source of truth.
 _USER_CONFIRMATION_REQUIRES = ("full_name", "phone", "shipping_address", "shipping_city")
 _PAYMENT_CONFIRMATION_REQUIRES = ("user_confirmation", "phone", "shipping_address")
+
+# Circuit breaker (P8): the outbound about to be sent fires the breaker when it
+# is the 3rd consecutive identical response — it equals BOTH of the two most
+# recent outbounds of the same conversation.
+_LOOP_PREVIOUS_OUTBOUNDS = 2
+LOOP_SIDE_EFFECT = "circuit_breaker:loop_detected"
+
+
+def detect_outbound_loop(
+    candidate_text: str,
+    previous_outbound_texts: list[Optional[str]],
+) -> bool:
+    """True when ``candidate_text`` would be the 3rd consecutive identical
+    outbound: both of the two most recent outbounds match it EXACTLY.
+
+    Exact (``==``) comparison by design — no normalisation, no fuzziness — so
+    legitimately similar responses never trip it. A repeated-but-not-consecutive
+    response (A, B, A) never trips it either: with B in between, the two most
+    recent are (B, A), which can't both equal A.
+
+    Pure — no I/O. ``previous_outbound_texts`` is expected newest-first.
+    """
+    if len(previous_outbound_texts) < _LOOP_PREVIOUS_OUTBOUNDS:
+        return False
+    return all(
+        text == candidate_text
+        for text in previous_outbound_texts[:_LOOP_PREVIOUS_OUTBOUNDS]
+    )
+
+
+def _recent_outbound_stmt(client_id: uuid.UUID, conversation_id: uuid.UUID):
+    """Statement for the 2 most recent outbound texts of ONE conversation,
+    newest-first. Kept as a pure builder so tests can assert the tenant
+    filters (client_id + conversation_id) without a live DB."""
+    return (
+        select(Message.content)
+        .where(
+            Message.conversation_id == conversation_id,
+            Message.client_id == client_id,
+            Message.direction == "outbound",
+        )
+        .order_by(Message.created_at.desc())
+        .limit(_LOOP_PREVIOUS_OUTBOUNDS)
+    )
 
 
 def compute_context_updates(
@@ -212,6 +259,59 @@ async def process_agent_action(
             f"strategy_version mismatch: expected {conversation.strategy_version}, "
             f"got {strategy_version}"
         )
+
+    # --- 2.5 Circuit breaker: 3rd consecutive identical outbound (P8) --------
+    # Checked BEFORE persisting anything from this turn: a looping turn is
+    # aborted whole (no context merge, no outbound persisted — the messages
+    # trail only records what was actually sent; the two looping outbounds
+    # stay the most recent, so an LLM that keeps insisting stays suppressed).
+    # NOTE: n8n must check approved/final_response_text before sending — that
+    # cut is a known dependency, not implemented here.
+    previous_rows = await session.execute(
+        _recent_outbound_stmt(client_id, conversation.id)
+    )
+    if detect_outbound_loop(response_text, list(previous_rows.scalars().all())):
+        old_state = conversation.state
+        if conversation.state == "active":
+            # Same escalation path as the DAG auto-escalate below —
+            # active → human_handoff is already valid in state_machine.py.
+            await session.execute(
+                update(Conversation)
+                .where(Conversation.id == conversation.id)
+                .values(state="human_handoff")
+            )
+            conversation.state = "human_handoff"
+        # If already in human_handoff, no new transition — but the identical
+        # response is still suppressed (n8n doesn't cut on state yet).
+        side_effects.append(LOOP_SIDE_EFFECT)
+        session.add(
+            AuditLog(
+                client_id=client_id,
+                event_type="circuit_breaker",
+                entity_type="conversation",
+                entity_id=conversation.id,
+                actor_type="system",
+                new_value={
+                    "old_state": old_state,
+                    "new_state": conversation.state,
+                    "reason": "loop_detected",
+                    "identical_count": _LOOP_PREVIOUS_OUTBOUNDS + 1,
+                },
+            )
+        )
+        await session.flush()
+        logger.warning(
+            "Circuit breaker fired on conversation %s: 3rd consecutive "
+            "identical outbound suppressed",
+            conversation.id,
+        )
+        return {
+            "approved": False,
+            "final_response_text": "",
+            "new_state": conversation.state,
+            "side_effects": side_effects,
+            "rejection_reason": "loop_detected",
+        }
 
     # --- 3. Persist extracted_data → extracted_context with DAG gates --------
     if extracted_data:

--- a/tests/services/test_agent_action.py
+++ b/tests/services/test_agent_action.py
@@ -366,3 +366,223 @@ def test_purchase_record_keys_match_contract():
     assert set(record.keys()) == {
         "date", "product_id", "quantity", "total", "conversation_id",
     }
+
+
+# ---------------------------------------------------------------------------
+# P8 — circuit breaker: 3rd consecutive identical outbound
+# ---------------------------------------------------------------------------
+import asyncio
+from types import SimpleNamespace
+
+from app.models.core import AuditLog, Message
+from app.services.agent_action import (
+    LOOP_SIDE_EFFECT,
+    _recent_outbound_stmt,
+    detect_outbound_loop,
+    process_agent_action,
+)
+
+_SAME = "Lo siento, pero aquí solo hablamos de café. ¿Te interesa algo del menú?"
+
+
+def test_loop_fires_on_third_identical():
+    """2 previous identical outbounds + the same candidate = 3rd → fires."""
+    assert detect_outbound_loop(_SAME, [_SAME, _SAME]) is True
+
+
+def test_loop_does_not_fire_on_second_identical():
+    """Only 1 previous identical: it's the 2nd, not the 3rd → no fire."""
+    assert detect_outbound_loop(_SAME, [_SAME]) is False
+
+
+def test_loop_does_not_fire_with_no_history():
+    assert detect_outbound_loop(_SAME, []) is False
+
+
+def test_loop_does_not_fire_on_non_consecutive_repeat():
+    """A, B, A: with B in between, the two most recent are (B, A) → no fire."""
+    assert detect_outbound_loop("A", ["B", "A"]) is False
+
+
+def test_loop_does_not_fire_on_different_texts():
+    """3 consecutive but different texts → exact comparison never fires."""
+    assert detect_outbound_loop("C", ["B", "A"]) is False
+
+
+def test_loop_comparison_is_exact_not_fuzzy():
+    """A single-character difference is a different response by design."""
+    assert detect_outbound_loop(_SAME, [_SAME, _SAME + " "]) is False
+
+
+def test_recent_outbound_stmt_is_tenant_safe_ordered_and_limited():
+    """The previous-outbounds read must filter by client_id AND conversation_id
+    AND direction='outbound', newest-first, limit 2 — tenant isolation is not
+    optional. Asserted on the compiled statement, no DB needed."""
+    client_id = uuid.UUID("00000000-0000-0000-0000-000000000001")
+    conv_id = uuid.UUID("00000000-0000-0000-0000-000000000009")
+    sql = str(_recent_outbound_stmt(client_id, conv_id))
+    assert "messages.client_id" in sql
+    assert "messages.conversation_id" in sql
+    assert "messages.direction" in sql
+    assert "ORDER BY messages.created_at DESC" in sql
+    assert "LIMIT" in sql
+
+
+# --- stub session: realistic process_agent_action paths without a DB --------
+class _StubResult:
+    def __init__(self, scalar=None, scalars_list=None):
+        self._scalar = scalar
+        self._scalars_list = scalars_list or []
+
+    def scalar_one_or_none(self):
+        return self._scalar
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return self._scalars_list
+
+
+class _StubSession:
+    """Answers execute() from an ordered queue and records every statement,
+    so tests can assert WHAT was executed on the real code path."""
+
+    def __init__(self, results):
+        self._results = list(results)
+        self.executed = []
+        self.added = []
+
+    async def execute(self, stmt, params=None):
+        self.executed.append(stmt)
+        if self._results:
+            return self._results.pop(0)
+        return _StubResult()
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    async def flush(self):
+        pass
+
+
+_CLIENT_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+
+
+def _make_conversation(state="active"):
+    return SimpleNamespace(
+        id=_CONV_ID,
+        client_id=_CLIENT_ID,
+        client_user_id=uuid.uuid4(),
+        state=state,
+        strategy_version=3,
+        extracted_context={},
+        active_goal="close_sale",
+    )
+
+
+def test_breaker_fires_escalates_and_suppresses_response():
+    """Fire path end-to-end: 2 identical previous outbounds + same text →
+    human_handoff, circuit_breaker side_effect, approved=False, empty
+    final_response_text, and NO outbound Message persisted (only AuditLog)."""
+    conversation = _make_conversation(state="active")
+    session = _StubSession(
+        [
+            _StubResult(scalar=conversation),           # load conversation
+            _StubResult(scalars_list=[_SAME, _SAME]),   # 2 previous outbounds
+            # state UPDATE needs no result
+        ]
+    )
+
+    result = asyncio.run(
+        process_agent_action(
+            session=session,
+            client_id=_CLIENT_ID,
+            conversation_id=_CONV_ID,
+            strategy_version=3,
+            response_text=_SAME,
+        )
+    )
+
+    assert result["approved"] is False
+    assert result["final_response_text"] == ""
+    assert result["new_state"] == "human_handoff"
+    assert result["side_effects"] == [LOOP_SIDE_EFFECT]
+    assert result["rejection_reason"] == "loop_detected"
+    assert conversation.state == "human_handoff"
+
+    # the previous-outbounds read on the real path is exactly the tenant-safe
+    # builder statement (client_id + conversation_id + direction filters)
+    assert str(session.executed[1]) == str(_recent_outbound_stmt(_CLIENT_ID, _CONV_ID))
+
+    # the 3rd identical outbound is NOT persisted; the audit trail is
+    assert not any(isinstance(obj, Message) for obj in session.added)
+    audit = [obj for obj in session.added if isinstance(obj, AuditLog)]
+    assert len(audit) == 1
+    assert audit[0].event_type == "circuit_breaker"
+    assert audit[0].new_value["reason"] == "loop_detected"
+    # the audit payload carries the count, never the response content
+    assert _SAME not in str(audit[0].new_value)
+
+
+def test_breaker_suppresses_without_transition_when_already_handed_off():
+    """Already in human_handoff (n8n doesn't cut on state yet): the identical
+    response is still suppressed, but no new transition is attempted."""
+    conversation = _make_conversation(state="human_handoff")
+    session = _StubSession(
+        [
+            _StubResult(scalar=conversation),
+            _StubResult(scalars_list=[_SAME, _SAME]),
+        ]
+    )
+
+    result = asyncio.run(
+        process_agent_action(
+            session=session,
+            client_id=_CLIENT_ID,
+            conversation_id=_CONV_ID,
+            strategy_version=3,
+            response_text=_SAME,
+        )
+    )
+
+    assert result["approved"] is False
+    assert result["new_state"] == "human_handoff"
+    assert result["side_effects"] == [LOOP_SIDE_EFFECT]
+    # only the 2 selects ran — no state UPDATE was issued
+    assert len(session.executed) == 2
+    assert not any(isinstance(obj, Message) for obj in session.added)
+
+
+def test_no_fire_normal_flow_persists_outbound():
+    """Regression: non-consecutive repeat (B, A then A again) does NOT fire —
+    the turn flows normally, approved=True, outbound persisted."""
+    conversation = _make_conversation(state="active")
+    client = SimpleNamespace(business_rules={})
+    session = _StubSession(
+        [
+            _StubResult(scalar=conversation),            # load conversation
+            _StubResult(scalars_list=["B", "A"]),        # previous outbounds
+            _StubResult(scalar=client),                  # client for auto-escalate
+        ]
+    )
+
+    result = asyncio.run(
+        process_agent_action(
+            session=session,
+            client_id=_CLIENT_ID,
+            conversation_id=_CONV_ID,
+            strategy_version=3,
+            response_text="A",
+        )
+    )
+
+    assert result["approved"] is True
+    assert result["final_response_text"] == "A"
+    assert result["new_state"] == "active"
+    assert LOOP_SIDE_EFFECT not in result["side_effects"]
+
+    outbound = [obj for obj in session.added if isinstance(obj, Message)]
+    assert len(outbound) == 1
+    assert outbound[0].direction == "outbound"
+    assert outbound[0].content == "A"


### PR DESCRIPTION
## Qué hace

Freno determinista a loops conversacionales (caso real de la auditoría: 19 respuestas idénticas en 29 min, 70 mensajes, 0% progreso DAG, sin freno). Regla en backend, sin LLM:

- **Disparo**: el outbound a punto de enviarse es EXACTAMENTE igual a los 2 outbounds más recientes de la conversación (3er idéntico consecutivo). Comparación exacta por diseño — sin fuzz, sin falsos positivos; A,B,A no dispara.
- **Acción**: `active → human_handoff` (misma transición del auto-escalate del DAG), evento `circuit_breaker` en audit_log (lleva el conteo, nunca el contenido), side_effect `circuit_breaker:loop_detected`, y el turno retorna `approved=False` con `final_response_text=""`.
- El 3er outbound idéntico **no se persiste**: el trail refleja solo lo enviado, y el breaker sigue suprimiendo si el LLM insiste — también cuando la conversación ya está en `human_handoff`.
- Lectura de los 2 previos: query mínima tenant-safe (`client_id` + `conversation_id` + `direction='outbound'`, newest-first, LIMIT 2) vía builder puro testeable.

## Qué NO hace (dependencia registrada)

El corte REAL depende de n8n: hoy manda `final_response_text` sin chequear `approved` ni estado. Ese cambio + la notificación humana quedan fuera de scope, registrados junto al loop de texto variable (candidato P9) en `sales-ai-docs/docs/briefs/p8-limitaciones-conocidas.md`. Sin schema, sin migración, sin cambio de DAG, sin tocar n8n.

## Tests

- Matriz pura del detector: dispara al 3ro; no al 2do, ni con no-consecutivos, ni con textos distintos, ni con diferencia de 1 carácter.
- Guardia de tenant isolation sobre el statement compilado (filtros client_id + conversation_id + direction, orden, límite).
- 3 recorridos de `process_agent_action` con sesión stub (sin DB): disparo completo, supresión sin transición en `human_handoff`, y flujo normal intacto con outbound persistido.
- Suite completa verde: **137 passed** (incluye regresión P2/P3/ADR-008).

🤖 Generated with [Claude Code](https://claude.com/claude-code)