### PR TITLE
feat(goal-strategy): orientación oportunista de ORDER_FIELDS en el directive pre-producto

### DIFF
--- a/sales-ai-docs/docs/briefs/impl-brief-order-fields-directive.md
+++ b/sales-ai-docs/docs/briefs/impl-brief-order-fields-directive.md
@@ -1,0 +1,87 @@
+# Brief de implementación — Captura oportunista de ORDER_FIELDS en el directive
+
+> **Origen**: diagnóstico del slot perdido en la primera venta (Hipótesis B confirmada).
+> El LLM extrajo `{}` en el turno donde la clienta dijo "500 molido honey rojo", porque
+> el directive solo pedía `product_id` y las keys de ORDER_FIELDS solo viven enterradas
+> en el muro del prompt (que el modelo ignora). Consecuencia: re-pregunta + doble
+> confirmación.
+>
+> **Sistema REAL**: backend FastAPI en prod, Postgres 6 tablas post-007, migración 010,
+> P2/P3/P8/ADR-008 mergeados. Edita código vivo. NO rediseña. NO toca schema.
+>
+> **Disciplina**: plan por archivo antes de codear, espera confirmación. Un commit con
+> tests, suite verde. Rama nueva desde main. NO desplegar.
+
+---
+
+## La causa raíz (confirmada en datos)
+
+- `extracted_data` del turno de 19:58 = `{}` (el LLM no propuso nada). Backend y n8n
+  verificados: no filtraron; el `{}` salió del modelo.
+- El LLM captura fielmente lo que el **directive** le orienta (capturó teléfono cuando
+  el directive pidió teléfono, etc.) pero ignora lo que solo está en el muro del prompt.
+- `quantity`/`grind_preference`/`roast_preference` son ORDER_FIELDS: NO son
+  `required_fields` de ningún checkpoint del DAG, así que el directive nunca los
+  menciona. La única referencia es una línea genérica al fondo del prompt → ignorada.
+
+**Por tanto el fix NO es tocar el `system_prompt_template`** (ahí ya está la línea y no
+funciona — sería repetir el error de 6 migraciones). El fix va en la construcción del
+**directive** (`goal_strategy.py`), que es la parte que el LLM sí obedece.
+
+## Las tres condiciones de diseño (confirmadas)
+
+1. **En el directive, no en el prompt**: la orientación se añade al texto del directive
+   que produce el `GoalStrategyEngine`, no al prompt en DB. Sin migración.
+2. **Oportunista, NO bloqueante**: la línea orienta "si el cliente menciona molienda o
+   cantidad, captúrala" — NUNCA "pregunta por la molienda" ni la convierte en paso
+   obligatorio. Los ORDER_FIELDS siguen sin ser checkpoints; el DAG no cambia; el cierre
+   no gana un paso. Es captura, no gatekeeping.
+3. **Contextual a la fase temprana**: la orientación aparece SOLO mientras `product_id`
+   NO esté resuelto (fase donde el cliente habla del producto y sus características). Una
+   vez elegido el producto, la línea desaparece del directive para no ensuciar las fases
+   de nombre/dirección/pago donde molienda/cantidad ya no vienen al caso.
+
+## El fix
+
+En `goal_strategy.py`, donde se construye el `directive` / su texto:
+
+- Cuando el checkpoint `product_matched` está pendiente (es decir, `product_id` aún no
+  está en el contexto), añadir al directive una línea corta y de prioridad visible (no
+  enterrada), del tipo:
+  `ORDER DETAILS: if the customer mentions grind, roast, or quantity, capture it into`
+  `extracted_data (grind_preference / roast_preference / quantity). Do NOT ask for these`
+  `proactively — only capture what they volunteer.`
+  (Ajustar el wording al estilo existente del directive; mantenerlo breve.)
+- Cuando `product_id` YA está resuelto, esa línea NO se incluye.
+- No tocar los `required_fields`, ni el orden del DAG, ni los gates. ORDER_FIELDS siguen
+  fuera del DAG; solo se mejora su captura vía orientación del LLM.
+
+## Tests (puros, sin DB) — en `tests/services/test_goal_strategy.py`
+
+1. **Aparece en fase temprana**: con `product_id` ausente en el contexto, el directive
+   generado INCLUYE la orientación de ORDER_FIELDS.
+2. **Desaparece tras elegir producto**: con `product_id` presente, el directive NO
+   incluye la línea de ORDER_FIELDS.
+3. **No es bloqueante**: verificar que la presencia/ausencia de la línea NO cambia qué
+   checkpoint está activo ni los `required_fields` — el DAG se comporta idéntico. (El
+   fix solo añade texto orientativo; no altera la lógica de progreso.)
+4. **Wording no imperativo de pregunta**: el texto orienta captura, no instruye a
+   preguntar (aserción sobre el contenido del directive: contiene "capture"/"if the
+   customer mentions", no "ask for grind").
+5. **Regresión**: los ~22 tests existentes de goal_strategy siguen verdes; el directive
+   de fases posteriores (lead_qualified, shipping, etc.) es byte-idéntico al actual.
+
+## Cierre
+
+- Un commit: cambio en goal_strategy.py + tests. Verde.
+- NO migración, NO schema, NO tocar system_prompt_template, NO n8n, NO deploy.
+- Reportar: archivo:línea del cambio, tests añadidos, y confirmación de que el directive
+  de las fases post-product es idéntico (regresión).
+
+## Nota para el futuro (NO implementar)
+
+Este fix es ESTRECHO: resuelve la captura de ORDER_FIELDS. El diagnóstico reveló un
+patrón MÁS AMPLIO —el LLM solo captura lo que pregunta, ignora datos espontáneos de
+cualquier campo (nombre, ciudad, cantidad dichos de una vez)—. NO se ataca aquí. Si
+aparece evidencia de que ese patrón cuesta ventas en otros campos, será su propio ADR.
+Registrado como limitación conocida, no como tarea.

--- a/sales-ai-docs/docs/postmortems/diagnostico-slot-perdido-2026-07-15.md
+++ b/sales-ai-docs/docs/postmortems/diagnostico-slot-perdido-2026-07-15.md
@@ -1,0 +1,57 @@
+# Diagnóstico — Slot perdido en la primera venta (Hipótesis B confirmada)
+
+**Fecha del diagnóstico**: 2026-07-19 · **Turno analizado**: 2026-07-15 19:58 UTC (conversación `31e4…09c8`) · **Origen**: `hallazgos-primera-venta.md` §2 · **Fix derivado**: `docs/briefs/impl-brief-order-fields-directive.md`
+
+**Convención de evidencia**: timestamps UTC y message_ids = confirmado con SELECT read-only contra la Postgres viva; `[n8n]` = leído del workflow vivo `cafe_arenillo_v2`; `archivo:línea` = repo. PII enmascarada.
+
+---
+
+## La pregunta
+
+En el turno donde la clienta dijo **"Me interesa la de 500 molido honey rojo"** (19:58:04), el bot no capturó producto, cantidad ni molienda — los re-preguntó ~5.5 minutos después, causando doble confirmación. Tres hipótesis a discriminar:
+
+- **A** — el LLM extrajo pero el backend lo descartó (pariente del bug P2) → fix determinista en backend.
+- **B** — el LLM no extrajo nada en ese turno → fix en orientación del LLM (prompt/directive).
+- **C** — el 500g inexistente rompió la reconciliación pedido↔catálogo → fix en manejo de presentación inexistente.
+
+## Veredicto: B, concluyente
+
+El LLM no propuso ningún slot en ese turno. La evidencia cierra las tres fronteras posibles de pérdida:
+
+### 1. El payload crudo del turno es `{}`
+
+El outbound que responde al mensaje es `fe96a840-…-5aef1041b411` (19:58:17, gpt-4o-mini). Su `messages.extracted_data` literal: **`{}`**. Y ese campo guarda la propuesta **cruda**: `agent_action.py:355` persiste el `extracted_data` del request sin mutarlo (`compute_context_updates` construye dicts nuevos, nunca toca el input).
+
+### 2. n8n reenvía el output del LLM textual, sin filtrar
+
+`[n8n: cafe_arenillo_v2 → "Validate and Prepare Action"]`: el nodo hace
+`extracted_data: (parsed.extracted_data && typeof … === 'object' && !Array.isArray(…)) ? parsed.extracted_data : {}` — reenvío verbatim, sin whitelist de keys. El `safeFallback` ("Disculpa, no entendí bien…") **no** disparó: el `response_text` entregado fue la corrección real a 340g, así que el JSON del modelo se parseó bien y el `{}` salió del propio modelo.
+
+### 3. El backend no rechazó nada
+
+El `agent_turn` de 19:58:17.345 en audit_log: `{"side_effects": []}` — ni `context_updated` ni `warning:*`. Todo camino de rechazo de gate emite warning observable (`agent_action.py:221-240`). Cero warnings + cero merge = input vacío, no filtrado silencioso.
+
+**Hipótesis A muerta.** (Único microhueco no determinable: si el LLM hubiera emitido `extracted_data` como *array*, n8n lo coerce a `{}` en silencio — indistinguible en datos sin la respuesta cruda de OpenAI, que no se loguea. Aun ese caso sería output malformado del LLM: familia B, no descarte del backend. Candidato a log en n8n cuando se haga P5.)
+
+## Por qué el LLM no extrajo (sub-diagnóstico de B)
+
+- **El directive de ese turno pedía solo `product_id`, y en voz baja.** El `strategy_snapshot` literal de la conversación: `current_checkpoint: "product_matched"`, `missing_fields: ["product_id"]`. El motor es puro y determinista (`goal_strategy.py`); con contexto vacío el directive era `SALES PROGRESS 0% / NEXT INFO NEEDED: product_id / HINT (low priority…): help the customer choose a product…` + "Do NOT mention or push…".
+- **El directive jamás pide quantity/grind/roast**: son `ORDER_FIELDS`, no son `required_fields` de ningún checkpoint — el motor no los conoce.
+- **La única instrucción de extracción es genérica y enterrada**: una línea al fondo del system prompt (`[n8n: "Build LLM Prompt"]`: lista de keys válidas — que SÍ incluye `quantity` y `grind_preference` — más "Only extract data the customer explicitly stated"). El modelo la ignoró en fase conversacional.
+- **Patrón en los 12 turnos**: el LLM extrajo casi exclusivamente lo que él mismo acababa de preguntar (nombre tras pedir nombre, teléfono tras pedir teléfono…). Lo ofrecido espontáneamente fuera de fase ("molido" a las 19:58, el producto mismo) no se capturó hasta que el guion llegó ahí — `product_id` recién en el último turno (20:04:36).
+
+## C descartada estructuralmente
+
+No existe reconciliación pedido↔catálogo en el backend: `compute_context_updates` no tiene gate para `product_id` (pasa sin validar contra `products`) y nada matchea cantidad/presentación. La corrección a 340g ocurrió en el **mismo turno** (19:58:17), dentro del `response_text`, autoría del LLM leyendo el catálogo del `business_context` (único producto: 340g, $40.000). No hubo intento de captura que fallara. Si el "500" inexistente *influyó* en la cautela del modelo, no es determinable — el mecanismo que C postula no existe en el sistema.
+
+## P2 descartado como causa
+
+Commit `0a0c2de` ("P2: persist quantity/grind/roast…") es del **2026-06-14**, un mes antes de la venta (último merge previo a la venta: 2026-07-05, PR #50; CI/CD despliega en push a main). Prueba en datos, misma conversación: `quantity=2` mergeó a las 20:03:05 y `grind_preference` a las 20:04:06 (`context_updated` en audit_log). Cuando el LLM propuso, el backend persistió a la primera, siempre.
+
+## Hallazgo incidental (sin fix en esta rama)
+
+`conversations.message_count` doble-cuenta los inbound y no cuenta los outbound: la conversación de la venta registra `28` con 26 filas reales (14 in + 12 out; 14×2=28). Origen probable: `ingest.py:204-212` (UPDATE SQL + mutación del atributo ORM del mismo contador). Cosmético — nada lo consume para lógica — pero registrado.
+
+## Dónde vive el fix
+
+En la orientación del LLM — el directive (`goal_strategy.py`), la parte que el modelo sí obedece — no en el backend ni en reconciliación de catálogo. Implementación: `docs/briefs/impl-brief-order-fields-directive.md`. Limitación conocida más amplia (el LLM solo captura lo que pregunta) registrada en la nota final de ese brief; no se ataca aquí.

--- a/sales_agent_api/app/services/goal_strategy.py
+++ b/sales_agent_api/app/services/goal_strategy.py
@@ -70,6 +70,19 @@ class StrategyDirective:
             lines.append(
                 f"HINT (low priority, only when the conversation flows there naturally): {self.next_action.lower()}",
             )
+            # Order details (grind/roast/quantity) are ORDER_FIELDS, not DAG
+            # checkpoints — the engine never asks for them. But the early,
+            # product-talk phase is exactly when customers volunteer them, and
+            # the generic extraction line buried in the system prompt gets
+            # ignored (see diagnostico-slot-perdido-2026-07-15). Orient capture
+            # here, pre-product only; once product_id is set the line drops out
+            # so later phases stay untouched.
+            if "product_id" in self.missing_fields:
+                lines.append(
+                    "ORDER DETAILS: if the customer mentions grind, roast, or quantity, "
+                    "capture it in extracted_data (grind_preference / roast_preference / quantity). "
+                    "Do NOT ask for these proactively — only capture what they volunteer."
+                )
 
         lines += [
             "IMPORTANT: Your priority is to have a warm, natural conversation. Answer what the customer asks.",

--- a/tests/services/test_goal_strategy.py
+++ b/tests/services/test_goal_strategy.py
@@ -233,3 +233,60 @@ def test_19_no_intent_checkpoint_remains():
         },
     )
     assert d2.all_complete
+
+
+# ---------------------------------------------------------------------------
+# ORDER_FIELDS capture orientation (opportunistic, pre-product phase only)
+# ---------------------------------------------------------------------------
+
+def test_20_order_details_line_in_pre_product_phase():
+    """While product_id is unresolved, the directive orients ORDER_FIELDS capture."""
+    d = engine.compute("close_sale", {})
+    prompt = d.to_prompt()
+    assert "ORDER DETAILS" in prompt
+    assert "grind_preference" in prompt
+    assert "quantity" in prompt
+    # Also when other data arrived first but product is still unresolved
+    d2 = engine.compute("close_sale", {"full_name": "Juan", "phone": "3001234567"})
+    assert "ORDER DETAILS" in d2.to_prompt()
+
+
+def test_21_order_details_line_gone_after_product_matched():
+    """Once product_id is set, the line disappears in every later phase."""
+    base = {"product_id": "abc"}
+    phases = [
+        base,  # lead_qualified active
+        {**base, "full_name": "Juan", "phone": "3001234567"},  # shipping active
+        {**base, "full_name": "Juan", "phone": "3001234567",
+         "shipping_address": "Calle 10", "shipping_city": "Manizales"},  # user_confirmed active
+        {**base, "full_name": "Juan", "phone": "3001234567",
+         "shipping_address": "Calle 10", "shipping_city": "Manizales",
+         "user_confirmation": True},  # payment active
+        {**base, "full_name": "Juan", "phone": "3001234567",
+         "shipping_address": "Calle 10", "shipping_city": "Manizales",
+         "user_confirmation": True, "payment_confirmation": True},  # all_complete
+    ]
+    for data in phases:
+        assert "ORDER DETAILS" not in engine.compute("close_sale", data).to_prompt()
+
+
+def test_22_order_details_is_prompt_text_only():
+    """The orientation never alters DAG behaviour: checkpoint, missing fields
+    and progress are identical to what the engine reported pre-fix."""
+    d = engine.compute("close_sale", {})
+    assert d.current_checkpoint == "product_matched"
+    assert d.missing_fields == ["product_id"]
+    assert d.progress_pct == 0
+    d2 = engine.compute("close_sale", {"quantity": 2, "grind_preference": "molido"})
+    # ORDER_FIELDS in context never complete a checkpoint nor move progress
+    assert d2.current_checkpoint == "product_matched"
+    assert d2.progress_pct == 0
+
+
+def test_23_order_details_wording_captures_not_asks():
+    """The line orients capture of volunteered data — it must not instruct
+    the LLM to ask for grind/roast/quantity."""
+    prompt = engine.compute("close_sale", {}).to_prompt()
+    assert "if the customer mentions" in prompt
+    assert "Do NOT ask for these proactively" in prompt
+    assert "ask for grind" not in prompt


### PR DESCRIPTION
## Origen

Diagnóstico del slot perdido en la primera venta cerrada (2026-07-15, conversación `31e4…09c8`): en el turno donde la clienta dijo "500 molido honey rojo", el LLM extrajo `{}`. **Hipótesis B confirmada** con evidencia en las tres fronteras — payload crudo persistido `{}`, reenvío verbatim verificado en el nodo vivo de n8n, cero side_effects de rechazo en el backend. El directive solo pedía `product_id` y la línea genérica de extracción del prompt se ignora. Consecuencia: re-pregunta de "molido" 5.5 min después + doble confirmación.

Cadena de evidencia completa: `sales-ai-docs/docs/postmortems/diagnostico-slot-perdido-2026-07-15.md` (en este PR). Brief de implementación: `sales-ai-docs/docs/briefs/impl-brief-order-fields-directive.md` (en este PR).

## El fix

`goal_strategy.py:to_prompt()` — cuando `product_id` aún no está resuelto (fase pre-producto, donde el cliente habla del producto y ofrece detalles espontáneos), el directive añade:

> ORDER DETAILS: if the customer mentions grind, roast, or quantity, capture it in extracted_data (grind_preference / roast_preference / quantity). Do NOT ask for these proactively — only capture what they volunteer.

- **Oportunista, no bloqueante**: orienta captura, jamás instruye a preguntar. ORDER_FIELDS siguen fuera del DAG.
- **Contextual**: con `product_id` resuelto la línea desaparece — el directive de las fases posteriores (lead_qualified, shipping, confirmación, pago) es idéntico al actual.
- Cero cambios en `compute()`, checkpoints, `required_fields`, gates o schema. Sin migración, sin tocar `system_prompt_template`, sin n8n.

## Tests

Tests 20-23 en `tests/services/test_goal_strategy.py` (puros, sin DB):
- Aparece con contexto vacío y con contexto parcial sin producto.
- Desaparece en las 4 fases posteriores y en `all_complete`.
- El DAG se comporta idéntico (checkpoint/missing_fields/progreso intactos; ORDER_FIELDS en contexto siguen sin mover progreso).
- Wording de captura, no imperativo de pregunta.

**Suite completa: 141 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)