### PR TITLE
feat: ADR-009 — cierre del lazo de handoff (endpoint confirm-payment + aviso operador)

### DIFF
--- a/sales-ai-docs/docs/decisions/ADR-009-handoff-closure-loop.md
+++ b/sales-ai-docs/docs/decisions/ADR-009-handoff-closure-loop.md
@@ -1,0 +1,158 @@
+# ADR-009 — Cierre del lazo de handoff humano (confirmación de pago, notificación y corte)
+
+- **Estatus**: Propuesto
+- **Fecha**: 2026-07-19
+- **Decididores**: Sebastian + cofounder/principal architect
+- **Origen**: postmortem de la primera venta cerrada (`docs/postmortems/`), que reveló
+  que el tramo final del flujo de venta nunca ha corrido solo.
+
+> Numeración: siguiente ADR libre tras 008 (multiidioma). Confirmar que no colisione con
+> reservas informales (`purchase_intents` fue citado como "008" en ADRs viejos pero se
+> reasignó). Ajustar al mergear si hace falta.
+
+---
+
+## Contexto
+
+El postmortem de la primera venta cerrada estableció, con evidencia dura, que el core de
+recolección+validación funciona y es reproducible, PERO el tramo de cierre no existe
+operativamente:
+
+- `payment_confirmation` NUNCA se propuso ni persistió en la venta real. El DAG se detuvo
+  en `user_confirmed`. El cierre (pago, envío) ocurrió 100% fuera del sistema.
+- La venta NO se registró en `client_users.profile` (sin `payment_confirmed`, el registro
+  en agent_action no se escribe). La primera clienta quedó sin historial de compra.
+- En la única conversación con `human_handoff` real, hubo **7 outbounds DESPUÉS** de la
+  transición: n8n NO respeta el estado `human_handoff` — el corte de respuesta no existe.
+- La venta cerró porque el humano estaba mirando WhatsApp en vivo. Sin esa presencia, se
+  habría perdido en "te comparto los medios de pago".
+
+**Decisión de producto previa (vigente)**: el pago se valida por HUMANO, por fuera del
+sistema (el comprobante es una imagen que el sistema no ve ni persiste). No hay
+automatización de validación de pago, y está bien. Pero eso deja un hueco: no existe
+mecanismo para que el humano le comunique al sistema "el pago está confirmado".
+
+## El problema central
+
+`payment_confirmed` es un checkpoint arquitectónicamente ÚNICO en el DAG: su verdad vive
+FUERA del sistema entero — en el ojo de un humano mirando un comprobante. No lo puede
+proponer el LLM (el cliente diciendo "ya pagué" no es prueba) ni validar el backend (no
+ve la imagen). Es el punto donde el flujo determinista se encuentra con un juicio humano
+irreductible. Se necesita un **canal de vuelta** del humano al sistema, que hoy no existe.
+
+## Decisión
+
+Construir el lazo completo de cierre de handoff con arquitectura **endpoint-como-verdad
++ Telegram-como-piel**:
+
+### 1. El endpoint es la verdad (mecanismo estable)
+
+Nuevo endpoint autenticado, p.ej. `POST /api/v1/agent/confirm-payment`, con
+`conversation_id` (o `intent_id`). Al invocarse por un operador autorizado:
+- marca `payment_confirmed` en el contexto,
+- registra la venta en `client_users.profile` (purchases[], purchase_count,
+  lifecycle_stage) — cierra el hueco de la clienta sin historial,
+- transiciona la conversación a `closed`,
+- emite side_effect `sale_closed` en audit_log.
+
+**Auth como requisito de PRIMERA CLASE (no detalle)**: este endpoint es, en efecto, el
+botón "una venta se pagó". Si se dispara sin autorización, marca ventas falsas y corrompe
+datos de negocio. Mínimo: Bearer token de servicio (como el resto). Además, restringir a
+que solo el operador legítimo (vía el bot de Telegram autenticado) pueda dispararlo — el
+token del bot de Telegram no debe ser el mismo token de servicio genérico. Diseñar la
+auth explícitamente en implementación.
+
+### 2. Telegram es la piel (canal reemplazable)
+
+El endpoint no sabe de Telegram; Telegram es solo cómo el operador lo dispara. Si mañana
+se cambia de canal, el endpoint no cambia. Dos momentos de notificación:
+
+- **Aviso pre-pago** (cuando el DAG llega a `user_confirmed` — pedido y datos completos,
+  falta solo pagar): Telegram recibe "venta lista para cerrar, cliente por pagar, entra a
+  acompañar y revisar el comprobante" + link/ref a la conversación. El operador entra a
+  tiempo, NO después de que el sistema ya dio el pago por bueno.
+- **Confirmación post-revisión**: tras revisar el comprobante con sus ojos, el operador
+  pulsa un botón en Telegram que dispara el endpoint (§1). Ese es el único acto que marca
+  `payment_confirmed`.
+
+### 3. Corte de respuesta en n8n (arreglo, no construcción)
+
+Incluido en este proyecto porque el lazo no cierra sin él. Hoy n8n manda
+`final_response_text` sin chequear `approved` ni `conversation_state`. Cambio: n8n debe
+NO enviar al cliente si la conversación está en `human_handoff` o `closed`. Esto arregla
+el bug de los 7 outbounds post-handoff y hace efectivo TODO escalamiento (venta, P8,
+futuro). Toca n8n vivo → sesión con export antes/después.
+
+### 4. Cierre y reactivación
+
+Al confirmar el pago, la conversación pasa a `closed`. El bot no vuelve a responder EN ESA
+conversación. La reactivación para una PRÓXIMA venta NO requiere mecanismo nuevo: cuando
+el cliente vuelve a escribir, el `find/create conversation` del ingest crea una
+conversación NUEVA (la vieja está closed / pasó la ventana 24h) que nace en `active`. El
+estado terminal vive en la CONVERSACIÓN, no en el `client_user`. `closed` cierra la
+VENTA, no la RELACIÓN.
+
+## Alternativas consideradas
+
+**A. Palabra clave en WhatsApp (operador escribe /confirmar en el chat).** Rechazada:
+mezcla mensajes de operador con mensajes de cliente en el mismo canal; frágil de parsear;
+riesgo de que el cliente escriba el comando. El endpoint dedicado es más limpio.
+
+**B. Que el LLM marque payment_confirmed cuando el cliente dice "ya pagué".** Rechazada:
+viola la decisión de producto (el pago lo valida un humano) y la tesis del sistema (no se
+confía en el LLM para verdad de negocio). "Ya pagué" no es prueba de pago.
+
+**C. Tool de extracción de imagen del comprobante (OCR + validación de monto/fecha).**
+Rechazada en esta etapa (decisión previa): sube costo de tokens, requiere que el sistema
+vea imágenes (no lo hace), y le da al humano datos pre-masticados por IA menos confiables
+que su propia revisión del comprobante crudo. Reevaluable a volumen alto.
+
+**D. Cerrar dejando la conversación en human_handoff (no closed).** Rechazada: el humano
+termina la interacción (envío, etc.) por FUERA del bot; mantener la conversación "viva"
+en handoff no aporta y complica la reactivación. `closed` es más limpio y la reactivación
+por conversación nueva ya está soportada.
+
+## Consecuencias
+
+**Positivas:**
+- El sistema puede cerrar ventas SIN que el operador vigile WhatsApp en vivo — convierte
+  la venta afortunada en flujo reproducible. Es la brecha del postmortem.
+- Registra la venta en el profile → habilita (a futuro, no ahora) el reconocimiento del
+  cliente recurrente / fidelización (ADR de memoria de relación, en pausa).
+- Arregla el corte de respuesta roto → hace efectivo TODO escalamiento (venta, P8).
+- Endpoint estable + canal reemplazable → Telegram se puede cambiar sin tocar la lógica.
+
+**Negativas / costos:**
+- Es el proyecto más grande desde el inicio: endpoint + auth + bot de Telegram con
+  callbacks + arreglo de n8n + registro de venta. Cuatro piezas, dos en zonas sensibles
+  (n8n vivo, auth de dinero). La implementación DEBE descomponerse en varios commits
+  pequeños, no hacerse de una.
+- Introduce el primer canal de salida hacia el operador (Telegram) → nueva pieza
+  operacional que mantener (token del bot, secreto en Key Vault).
+- El aviso pre-pago depende de detectar `user_confirmed` de forma fiable → verificar que
+  ese checkpoint se marca consistentemente antes de conectar la notificación.
+
+## Plan de implementación (baby steps — NO de una)
+
+1. Endpoint `confirm-payment` (sin Telegram todavía): marca payment_confirmed + registra
+   venta en profile + cierra. Auth con Bearer. Tests de contrato (incl. auth rechaza no
+   autorizado). Se puede disparar a mano (curl/Postman) para probar.
+2. Arreglo del corte en n8n: no enviar si human_handoff/closed. Sesión n8n con export
+   antes/después. Verificar con una conversación de prueba que el bot se calla.
+3. Registro de venta en profile: verificar shape (purchases con quantity/total — reusa lo
+   de P2). Test de que una confirmación puebla el profile correctamente.
+4. Notificación Telegram — aviso pre-pago (user_confirmed → mensaje al operador).
+5. Notificación Telegram — botón de confirmación que dispara el endpoint (§1).
+6. End-to-end con un cliente real de prueba: pedido → user_confirmed → aviso Telegram →
+   operador revisa → botón → payment_confirmed → venta registrada → bot callado → closed.
+
+Cada paso: un commit, su test donde aplique, verificado antes del siguiente. Los pasos 1-3
+son backend (tu terreno fuerte); 2 toca n8n; 4-5 son la pieza nueva de Telegram.
+
+## Cuándo revisar
+
+- Si el volumen de ventas crece al punto de que la revisión manual de comprobantes es
+  cuello de botella → reevaluar la tool de extracción (alternativa C).
+- Si Telegram resulta incómodo para el operador → cambiar la piel sin tocar el endpoint.
+- Si se decide construir la fidelización / memoria de relación → este ADR ya dejó la
+  venta registrada en el profile como prerequisito cumplido.

--- a/sales_agent_api/app/api/v1/operator.py
+++ b/sales_agent_api/app/api/v1/operator.py
@@ -1,0 +1,102 @@
+"""POST /api/v1/operator/confirm-payment — operator closes a sale (ADR-009).
+
+Operator surface: authenticated with SALES_AI_OPERATOR_TOKEN (path-scoped in
+the auth middleware — the generic service token is NOT accepted here). This
+endpoint is, in effect, the "a sale was paid" button.
+"""
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.database import get_session
+from app.services.confirm_payment import (
+    ConfirmPaymentError,
+    ConversationNotFoundError,
+    OrderNotConfirmedError,
+    confirm_payment,
+)
+from app.services.state_machine import StateMachineError
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Request / Response schemas
+# ---------------------------------------------------------------------------
+class ConfirmPaymentRequest(BaseModel):
+    conversation_id: uuid.UUID
+
+
+class ConfirmPaymentResponse(BaseModel):
+    confirmed: bool
+    already_confirmed: bool
+    new_state: str
+    side_effects: list[str]
+
+
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+@router.post("/confirm-payment", response_model=ConfirmPaymentResponse)
+async def confirm_payment_endpoint(
+    request: Request,
+    body: ConfirmPaymentRequest,
+    session: AsyncSession = Depends(get_session),
+) -> ConfirmPaymentResponse:
+    """Mark a sale as paid after the operator reviewed the receipt.
+
+    Requires:
+      - Authorization: Bearer <SALES_AI_OPERATOR_TOKEN>
+      - X-Client-ID: <uuid of the tenant client>
+
+    Semantics:
+      - Idempotent: re-confirming an already-closed sale returns 200 with
+        already_confirmed=true and does NOT duplicate the purchase record.
+      - Strict precondition: 409 if the customer never confirmed the order
+        (no user_confirmation in context).
+    """
+    client_id: uuid.UUID = request.state.client_id  # set by auth middleware
+
+    try:
+        result = await confirm_payment(
+            session=session,
+            client_id=client_id,
+            conversation_id=body.conversation_id,
+        )
+        await session.commit()
+        return ConfirmPaymentResponse(confirmed=True, **result)
+
+    except ConversationNotFoundError as exc:
+        await session.rollback()
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+
+    except OrderNotConfirmedError as exc:
+        await session.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={"error": "order_not_confirmed", "message": str(exc)},
+        )
+
+    except StateMachineError as exc:
+        await session.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={"error": "invalid_state", "message": str(exc)},
+        )
+
+    except ConfirmPaymentError as exc:
+        await session.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+        )
+
+    except Exception as exc:
+        await session.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Confirm payment failed: {exc}",
+        )

--- a/sales_agent_api/app/main.py
+++ b/sales_agent_api/app/main.py
@@ -2,6 +2,8 @@
 
 Authentication:
   - Service-to-service Bearer token (SALES_AI_SERVICE_TOKEN env var)
+  - Operator Bearer token (SALES_AI_OPERATOR_TOKEN env var) — only valid on
+    /api/v1/operator/* and the only token valid there (ADR-009)
   - Constant-time comparison to prevent timing attacks
 
 Tenant identification:
@@ -31,6 +33,12 @@ logging.basicConfig(
 
 ENV = os.getenv("ENV", "dev")
 SERVICE_TOKEN = os.getenv("SALES_AI_SERVICE_TOKEN", "")
+# Operator surface (/api/v1/operator/*) has its own token (ADR-009): the
+# confirm-payment endpoint is the "a sale was paid" button — the generic
+# service token must not reach it, nor the operator token reach agent/ingest.
+OPERATOR_TOKEN = os.getenv("SALES_AI_OPERATOR_TOKEN", "")
+
+_OPERATOR_PATH_PREFIX = "/api/v1/operator/"
 
 # Endpoints that bypass auth
 _NO_AUTH_PATHS = {"/health", "/", "/api/docs", "/openapi.json"}
@@ -111,12 +119,19 @@ def create_app() -> FastAPI:
             return _unauthorized("Missing or invalid Authorization header")
 
         token = auth_header[len("Bearer "):]
-        if not SERVICE_TOKEN:
-            logger.error("SALES_AI_SERVICE_TOKEN is not configured")
-            return _server_error("Service token not configured")
+        if path.startswith(_OPERATOR_PATH_PREFIX):
+            if not OPERATOR_TOKEN:
+                logger.error("SALES_AI_OPERATOR_TOKEN is not configured")
+                return _server_error("Operator token not configured")
+            expected_token = OPERATOR_TOKEN
+        else:
+            if not SERVICE_TOKEN:
+                logger.error("SALES_AI_SERVICE_TOKEN is not configured")
+                return _server_error("Service token not configured")
+            expected_token = SERVICE_TOKEN
 
-        if not hmac.compare_digest(token.encode(), SERVICE_TOKEN.encode()):
-            return _unauthorized("Invalid service token")
+        if not hmac.compare_digest(token.encode(), expected_token.encode()):
+            return _unauthorized("Invalid token for this surface")
 
         # --- X-Client-ID header ---
         client_id_header = request.headers.get("X-Client-ID", "")
@@ -134,9 +149,11 @@ def create_app() -> FastAPI:
     # Register routers
     from app.api.v1.ingest import router as ingest_router
     from app.api.v1.agent import router as agent_router
+    from app.api.v1.operator import router as operator_router
 
     application.include_router(ingest_router, prefix="/api/v1/ingest", tags=["Ingest"])
     application.include_router(agent_router, prefix="/api/v1/agent", tags=["Agent"])
+    application.include_router(operator_router, prefix="/api/v1/operator", tags=["Operator"])
 
     @application.get("/health", tags=["Health"])
     async def health():

--- a/sales_agent_api/app/services/agent_action.py
+++ b/sales_agent_api/app/services/agent_action.py
@@ -184,6 +184,19 @@ def compute_context_updates(
     return accepted, strategy_updates, rejections
 
 
+def is_new_user_confirmation(strategy_accepted: dict, prior_context: dict) -> bool:
+    """True only on the turn user_confirmation FIRST lands (ADR-009 §2).
+
+    Pure — the transition (not the state) is what triggers the operator's
+    pre-payment notice; the LLM re-proposes the full cumulative extracted_data
+    every turn, so presence alone would re-fire on every later turn.
+    """
+    return (
+        "user_confirmation" in strategy_accepted
+        and not prior_context.get("user_confirmation")
+    )
+
+
 def _coerce_int(value) -> Optional[int]:
     """Best-effort int from an LLM-supplied value (may be int or string)."""
     if value is None:
@@ -339,7 +352,11 @@ async def process_agent_action(
             elif rej["field"] == "phone":
                 side_effects.append("warning:invalid_phone_rejected")
         if accepted:
-            new_context = {**(conversation.extracted_context or {}), **accepted}
+            prior_context = conversation.extracted_context or {}
+            newly_user_confirmed = is_new_user_confirmation(
+                strategy_accepted, prior_context
+            )
+            new_context = {**prior_context, **accepted}
             await session.execute(
                 update(Conversation)
                 .where(Conversation.id == conversation.id)
@@ -347,6 +364,8 @@ async def process_agent_action(
             )
             conversation.extracted_context = new_context
             side_effects.append(f"context_updated:{list(accepted.keys())}")
+            if newly_user_confirmed:
+                side_effects.append("checkpoint_completed:user_confirmed")
 
             # Profile merge + CRM lifecycle bump are driven ONLY by DAG strategy
             # fields — order details (quantity/grind/roast) never move lifecycle.

--- a/sales_agent_api/app/services/confirm_payment.py
+++ b/sales_agent_api/app/services/confirm_payment.py
@@ -1,0 +1,171 @@
+"""Operator payment confirmation — closes the handoff loop (ADR-009).
+
+`payment_confirmed` is the one checkpoint whose truth lives outside the whole
+system: a human looking at a payment receipt. The LLM must never propose it
+("ya pagué" is not proof) and the backend cannot verify it (it never sees the
+image). This service is the return channel: an authorized operator — via
+whatever skin (Telegram today) — asserts "the payment is real", and the system
+records the sale, closes the conversation and updates the customer profile.
+
+The conversation may be in `active` (the first real sale never escalated) or
+`human_handoff`; both transition to `closed` here. `closed` ends the SALE, not
+the relationship — a returning customer gets a fresh conversation via ingest.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Optional
+
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.core import AuditLog, Conversation
+from app.services.agent_action import (
+    _bump_lifecycle_stage,
+    _fetch_product_price,
+    _merge_profile,
+)
+from app.services.state_machine import validate_transition
+
+logger = logging.getLogger(__name__)
+
+
+class ConfirmPaymentError(Exception):
+    pass
+
+
+class ConversationNotFoundError(ConfirmPaymentError):
+    pass
+
+
+class OrderNotConfirmedError(ConfirmPaymentError):
+    """The customer never confirmed the order (no user_confirmation in context) —
+    there is nothing to close. Protects against confirming the wrong conversation."""
+    pass
+
+
+# Pure decision outcomes — kept as constants so the endpoint and tests share them.
+CONFIRM_OK = "ok"
+ALREADY_CONFIRMED = "already_confirmed"
+ORDER_NOT_CONFIRMED = "order_not_confirmed"
+
+
+def evaluate_confirmation(state: str, extracted_context: dict) -> str:
+    """Decide what an operator confirmation means for this conversation.
+
+    Pure — no I/O. Returns one of:
+      - ALREADY_CONFIRMED: sale already closed by a prior confirmation —
+        idempotent no-op (safe for double-taps / Telegram retries).
+      - ORDER_NOT_CONFIRMED: no user_confirmation in context — refuse.
+      - CONFIRM_OK: proceed.
+
+    Raises StateMachineError for states that cannot transition to closed
+    (e.g. a conversation closed WITHOUT payment — not re-confirmable).
+    """
+    if state == "closed" and extracted_context.get("payment_confirmation"):
+        return ALREADY_CONFIRMED
+    if not extracted_context.get("user_confirmation"):
+        return ORDER_NOT_CONFIRMED
+    validate_transition(state, "closed")
+    return CONFIRM_OK
+
+
+async def confirm_payment(
+    session: AsyncSession,
+    client_id: uuid.UUID,
+    conversation_id: uuid.UUID,
+) -> dict:
+    """Mark a sale as paid on behalf of a human operator.
+
+    In one transaction (caller commits):
+      1. payment_confirmation → extracted_context
+      2. sale recorded in client_users.profile (purchases[], purchase_count —
+         P2 shape) + lifecycle bump to 'customer'
+      3. conversation → closed
+      4. audit event `sale_closed` (actor_type='operator')
+
+    Returns dict with: already_confirmed, new_state, side_effects.
+    """
+    conv_row = await session.execute(
+        select(Conversation).where(
+            Conversation.id == conversation_id,
+            Conversation.client_id == client_id,
+        )
+    )
+    conversation: Optional[Conversation] = conv_row.scalar_one_or_none()
+    if conversation is None:
+        raise ConversationNotFoundError(
+            f"Conversation {conversation_id} not found for client {client_id}"
+        )
+
+    context = dict(conversation.extracted_context or {})
+    decision = evaluate_confirmation(conversation.state, context)
+
+    if decision == ALREADY_CONFIRMED:
+        return {
+            "already_confirmed": True,
+            "new_state": conversation.state,
+            "side_effects": [],
+        }
+
+    if decision == ORDER_NOT_CONFIRMED:
+        raise OrderNotConfirmedError(
+            f"Conversation {conversation_id} has no user_confirmation — "
+            "the customer never confirmed an order; nothing to close"
+        )
+
+    old_state = conversation.state
+    context["payment_confirmation"] = True
+    await session.execute(
+        update(Conversation)
+        .where(Conversation.id == conversation.id)
+        .values(extracted_context=context, state="closed")
+    )
+    conversation.extracted_context = context
+    conversation.state = "closed"
+
+    product_price = await _fetch_product_price(
+        session, client_id, context.get("product_id")
+    )
+    await _merge_profile(
+        session,
+        client_user_id=conversation.client_user_id,
+        extracted_context=context,
+        payment_just_confirmed=True,
+        conversation_id=conversation.id,
+        product_price=product_price,
+    )
+    await _bump_lifecycle_stage(session, conversation.client_user_id, "customer")
+
+    side_effects = [
+        "payment_confirmed_by_operator",
+        f"state_changed:{old_state}→closed",
+        "sale_recorded_in_profile",
+    ]
+    session.add(
+        AuditLog(
+            client_id=client_id,
+            event_type="sale_closed",
+            entity_type="conversation",
+            entity_id=conversation.id,
+            actor_type="operator",
+            new_value={
+                "old_state": old_state,
+                "new_state": "closed",
+                "side_effects": side_effects,
+            },
+        )
+    )
+    await session.flush()
+
+    logger.info(
+        "Sale closed by operator: conversation=%s old_state=%s",
+        conversation.id,
+        old_state,
+    )
+    return {
+        "already_confirmed": False,
+        "new_state": "closed",
+        "side_effects": side_effects,
+    }

--- a/tests/services/test_agent_action.py
+++ b/tests/services/test_agent_action.py
@@ -586,3 +586,25 @@ def test_no_fire_normal_flow_persists_outbound():
     assert len(outbound) == 1
     assert outbound[0].direction == "outbound"
     assert outbound[0].content == "A"
+
+
+# ---------------------------------------------------------------------------
+# is_new_user_confirmation — pre-payment notice trigger (ADR-009 §2)
+# ---------------------------------------------------------------------------
+
+def test_new_user_confirmation_fires_on_transition():
+    from app.services.agent_action import is_new_user_confirmation
+    assert is_new_user_confirmation({"user_confirmation": True}, {}) is True
+
+
+def test_new_user_confirmation_silent_when_already_confirmed():
+    """The LLM re-proposes cumulative data every turn — no re-notification."""
+    from app.services.agent_action import is_new_user_confirmation
+    assert is_new_user_confirmation(
+        {"user_confirmation": True}, {"user_confirmation": True}
+    ) is False
+
+
+def test_new_user_confirmation_silent_without_proposal():
+    from app.services.agent_action import is_new_user_confirmation
+    assert is_new_user_confirmation({"full_name": "Juan"}, {}) is False

--- a/tests/services/test_confirm_payment.py
+++ b/tests/services/test_confirm_payment.py
@@ -1,0 +1,69 @@
+"""Tests for the operator confirm-payment decision (ADR-009).
+
+Pure — evaluate_confirmation only, no DB. The DB-touching path (profile
+merge, lifecycle bump, audit) reuses agent_action helpers already covered
+there; the full transaction belongs to integration tests (known debt #1).
+"""
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../sales_agent_api"))
+
+import pytest
+from app.services.confirm_payment import (
+    ALREADY_CONFIRMED,
+    CONFIRM_OK,
+    ORDER_NOT_CONFIRMED,
+    evaluate_confirmation,
+)
+from app.services.state_machine import InvalidTransitionError, UnknownStateError
+
+# A context as the real first sale left it: order confirmed, payment pending.
+CONFIRMED_ORDER_CTX = {
+    "product_id": "abc",
+    "full_name": "Juan",
+    "phone": "3001234567",
+    "shipping_address": "Calle 10",
+    "shipping_city": "Manizales",
+    "quantity": 2,
+    "user_confirmation": True,
+}
+
+
+def test_active_with_confirmed_order_ok():
+    """The real first-sale shape: conversation still active (never escalated)."""
+    assert evaluate_confirmation("active", CONFIRMED_ORDER_CTX) == CONFIRM_OK
+
+
+def test_human_handoff_with_confirmed_order_ok():
+    assert evaluate_confirmation("human_handoff", CONFIRMED_ORDER_CTX) == CONFIRM_OK
+
+
+def test_closed_and_paid_is_idempotent():
+    """Double-tap / Telegram retry: no error, no duplicate purchase."""
+    ctx = {**CONFIRMED_ORDER_CTX, "payment_confirmation": True}
+    assert evaluate_confirmation("closed", ctx) == ALREADY_CONFIRMED
+
+
+def test_active_without_user_confirmation_refused():
+    """Strict precondition: nothing to close if the customer never confirmed."""
+    ctx = {k: v for k, v in CONFIRMED_ORDER_CTX.items() if k != "user_confirmation"}
+    assert evaluate_confirmation("active", ctx) == ORDER_NOT_CONFIRMED
+
+
+def test_empty_context_refused():
+    """The bot-loop handoff case: escalated conversation with empty context
+    must not be confirmable as a sale."""
+    assert evaluate_confirmation("human_handoff", {}) == ORDER_NOT_CONFIRMED
+
+
+def test_closed_without_payment_cannot_be_reconfirmed():
+    """A conversation closed by another path is terminal — closed→closed is
+    not a valid transition, so the operator gets an explicit error."""
+    with pytest.raises(InvalidTransitionError):
+        evaluate_confirmation("closed", CONFIRMED_ORDER_CTX)
+
+
+def test_unknown_state_raises():
+    with pytest.raises(UnknownStateError):
+        evaluate_confirmation("selling", CONFIRMED_ORDER_CTX)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -13,6 +13,7 @@ def _reload_app(monkeypatch):
     """Helper: set env vars and reimport app.main cleanly."""
     monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://user:pass@localhost:5432/test")
     monkeypatch.setenv("SALES_AI_SERVICE_TOKEN", "test-token-ci")
+    monkeypatch.setenv("SALES_AI_OPERATOR_TOKEN", "test-operator-token-ci")
     monkeypatch.setenv("ENV", "dev")
 
     # Drop cached modules so env vars are picked up
@@ -114,5 +115,97 @@ def test_api_endpoint_returns_400_without_client_id(monkeypatch):
                 headers={"Authorization": "Bearer test-token-ci"},
             )
         assert response.status_code == 400
+
+    asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Operator surface token scoping (ADR-009): two surfaces, two keys.
+# All cases below are rejected by the middleware — no DB is touched.
+# ---------------------------------------------------------------------------
+
+def test_operator_endpoint_rejects_service_token(monkeypatch):
+    """The generic service token must NOT open the confirm-payment surface."""
+    from httpx import AsyncClient
+    from httpx._transports.asgi import ASGITransport
+
+    application = _reload_app(monkeypatch)
+
+    async def _run():
+        async with AsyncClient(
+            transport=ASGITransport(app=application), base_url="http://test"
+        ) as client:
+            response = await client.post(
+                "/api/v1/operator/confirm-payment",
+                json={},
+                headers={"Authorization": "Bearer test-token-ci"},
+            )
+        assert response.status_code == 401
+
+    asyncio.run(_run())
+
+
+def test_agent_endpoint_rejects_operator_token(monkeypatch):
+    """The operator token must NOT open the agent/ingest surfaces."""
+    from httpx import AsyncClient
+    from httpx._transports.asgi import ASGITransport
+
+    application = _reload_app(monkeypatch)
+
+    async def _run():
+        async with AsyncClient(
+            transport=ASGITransport(app=application), base_url="http://test"
+        ) as client:
+            response = await client.post(
+                "/api/v1/agent/action",
+                json={},
+                headers={"Authorization": "Bearer test-operator-token-ci"},
+            )
+        assert response.status_code == 401
+
+    asyncio.run(_run())
+
+
+def test_operator_endpoint_rejects_missing_auth(monkeypatch):
+    from httpx import AsyncClient
+    from httpx._transports.asgi import ASGITransport
+
+    application = _reload_app(monkeypatch)
+
+    async def _run():
+        async with AsyncClient(
+            transport=ASGITransport(app=application), base_url="http://test"
+        ) as client:
+            response = await client.post("/api/v1/operator/confirm-payment", json={})
+        assert response.status_code == 401
+
+    asyncio.run(_run())
+
+
+def test_operator_endpoint_500_when_token_unconfigured(monkeypatch):
+    """Fail closed: with no operator token configured, the surface is unusable
+    (500), never falls back to the service token."""
+    from httpx import AsyncClient
+    from httpx._transports.asgi import ASGITransport
+
+    monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://user:pass@localhost:5432/test")
+    monkeypatch.setenv("SALES_AI_SERVICE_TOKEN", "test-token-ci")
+    monkeypatch.delenv("SALES_AI_OPERATOR_TOKEN", raising=False)
+    monkeypatch.setenv("ENV", "dev")
+    for mod in list(sys.modules.keys()):
+        if mod.startswith("app"):
+            del sys.modules[mod]
+    from app.main import app as application
+
+    async def _run():
+        async with AsyncClient(
+            transport=ASGITransport(app=application), base_url="http://test"
+        ) as client:
+            response = await client.post(
+                "/api/v1/operator/confirm-payment",
+                json={},
+                headers={"Authorization": "Bearer test-token-ci"},
+            )
+        assert response.status_code == 500
 
     asyncio.run(_run())


### PR DESCRIPTION
## Qué es

Implementación backend del **ADR-009 — Cierre del lazo de handoff humano** (incluido en este PR). Origen: el postmortem de la primera venta reveló que el tramo final del flujo nunca ha corrido solo — el pago se validó por un humano mirando WhatsApp en vivo, y el sistema nunca supo que vendió.

Tres commits, en orden:

### 1. `ecc6b3b` — docs: ADR-009
Endpoint-como-verdad + Telegram-como-piel + corte de respuesta en n8n.

### 2. `ed24178` — feat(operator): endpoint confirm-payment (§1)
`POST /api/v1/operator/confirm-payment` — el canal de vuelta del humano al sistema:
- Marca `payment_confirmation`, registra la venta en el profile (reusa `_merge_profile`/P2: `purchases[]` con quantity/total, `purchase_count`, lifecycle → `customer`), transiciona a `closed` (válido desde `active` y `human_handoff`) y audita `sale_closed` con `actor_type='operator'`.
- **Auth de primera clase**: `SALES_AI_OPERATOR_TOKEN` propio, escopado por path en el middleware — el token de servicio no abre `/operator/*` ni viceversa; sin token configurado, la superficie falla cerrada (500).
- **Idempotente** (re-confirmar → 200 `already_confirmed`, sin duplicar purchases) y **precondición estricta** (409 `order_not_confirmed` sin `user_confirmation` — protege contra confirmar la conversación equivocada, p.ej. el loop bot-a-bot).
- Sin migraciones: `closed` y sus transiciones ya existen; `audit_log.event_type` es VARCHAR sin CHECK.

### 3. `af716bf` — feat(agent-action): side_effect `checkpoint_completed:user_confirmed` (§2)
Gatillo del aviso pre-pago al operador. Solo dispara en la **transición** (helper puro `is_new_user_confirmation`): el LLM re-propone el contexto acumulado cada turno y sin el guard se re-notificaría cada turno.

## Tests

**151 passed** (suite completa): 7 puros de `evaluate_confirmation` + 4 de scoping de tokens + 3 del gatillo de transición + los 137 previos.

## Contexto operacional (ya desplegado fuera de este repo)

- Key Vault: `sales-ai-operator-token` y `telegram-bot-token` creados.
- Container App: env `SALES_AI_OPERATOR_TOKEN` cableada (secretref → KV vía managed identity) — el endpoint encuentra su token al desplegar.
- n8n (§3 corte + §2 piel, ya vivos): guardas en `IF Should Respond` y `Process Backend Response` (no enviar en `human_handoff`/`closed` ni turnos no aprobados), aviso Telegram por `checkpoint_completed:user_confirmed` **y** `circuit_breaker:loop_detected`, workflow `operator_confirm_telegram` con validación de `chat_id` del operador. Exports en `n8n_workflow/`.

**Al mergear**: el deploy activa el endpoint y el lazo queda completo → sigue el e2e del paso 6 del ADR (pedido de prueba → aviso → botón → venta cerrada + bot callado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)