### PR TITLE
docs(overview): arquitectura con diagramas (comunicación, n8n, estados, operador, datos)

### DIFF
--- a/sales-ai-docs/docs/architecture/overview.md
+++ b/sales-ai-docs/docs/architecture/overview.md
@@ -1,6 +1,6 @@
 # Arquitectura — Overview
 
-Este documento responde a la pregunta **"¿cómo está pensado este sistema?"**. Para el estado actual operacional, leer `../../CLAUDE.md`. Para el por qué de cada decisión, leer `../decisions/`.
+Este documento responde a la pregunta **"¿cómo está pensado este sistema?"**. Está hecho **con muchos diagramas a propósito**: cada uno cuenta un pedazo de la historia (quién habla con quién, cómo viaja un mensaje, cómo se recolectan los datos, cómo se decide). Para el estado actual operacional, leer `../../CLAUDE.md`. Para el por qué de cada decisión, leer `../decisions/`.
 
 ---
 
@@ -14,18 +14,53 @@ Sales AI Agent invierte esa relación. El LLM solo entiende y produce lenguaje n
 
 ---
 
+## El sistema de un vistazo (quién habla con quién)
+
+Antes de entrar en detalle, este es el mapa completo. Cada flecha es una comunicación real entre piezas:
+
+```mermaid
+flowchart LR
+    Cliente(["📱 Cliente<br/>WhatsApp"])
+    Chakra["Chakra HQ<br/>(API de WhatsApp)"]
+    LLM["🧠 OpenAI<br/>gpt-4o-mini"]
+    DB[("🗄️ PostgreSQL<br/>ground truth")]
+    KV["🔐 Key Vault<br/>secretos"]
+    Operador(["🧑‍💼 Operador<br/>Telegram"])
+
+    subgraph Azure["☁️ Azure Container Apps (cada servicio siempre encendido)"]
+        n8n["n8n<br/>orquestador del turno"]
+        Backend["Backend FastAPI<br/>el que gobierna"]
+    end
+
+    Cliente <-->|mensajes| Chakra
+    Chakra -->|webhook entrante| n8n
+    n8n -->|respuesta| Chakra
+    n8n <-->|2 llamadas por turno| Backend
+    n8n <-->|1 llamada por turno| LLM
+    Backend <-->|lee/escribe| DB
+    Backend -.->|carga secretos| KV
+    n8n -->|aviso + botón| Operador
+    Operador -->|confirma pago| n8n
+```
+
+**Cómo leerlo**: el cliente nunca habla directo con nuestro sistema — Chakra HQ es el intermediario con WhatsApp. **n8n** es el director de orquesta (no piensa, coordina). El **backend** es el cerebro con las reglas. El **operador humano** entra por Telegram cuando hay que confirmar un pago o rescatar una conversación.
+
+> **Nota de resiliencia**: n8n y el backend son dos servicios **separados** en Azure Container Apps, y **ambos** deben estar siempre encendidos. Si cualquiera de los dos se apaga por inactividad, un mensaje que llega mientras arranca en frío se pierde (ver `postmortems/n8n-scale-to-zero-2026-07-21.md`).
+
+---
+
 ## Las tres capas
 
 ```mermaid
 graph TB
     subgraph C1["Capa 1 — Lenguaje"]
-        LLM["LLM · gpt-4o-mini\nNLU + NLG · sin tools · sin loops · sin estado\n─────────────────────────────────────\nLee: texto del cliente · system prompt · directiva\nEscribe: response_text · extracted_data\nDecide: nada de la venta"]
+        LLM["LLM · gpt-4o-mini<br/>NLU + NLG · sin tools · sin loops · sin estado<br/>─────────────────────────────────────<br/>Lee: texto del cliente · system prompt · directiva<br/>Escribe: response_text · extracted_data<br/>Decide: nada de la venta"]
     end
     subgraph C2["Capa 2 — Política"]
-        POL["GoalStrategyEngine · DAG gates · state machine\n─────────────────────────────────────\nLee: extracted_context · business_rules\nEscribe: directiva del turno · accept/reject por slot\nDecide: orden de pedidos · cuándo escalar · qué admisible"]
+        POL["GoalStrategyEngine · DAG gates · state machine<br/>─────────────────────────────────────<br/>Lee: extracted_context · business_rules<br/>Escribe: directiva del turno · accept/reject por slot<br/>Decide: orden de pedidos · cuándo escalar · qué admisible"]
     end
     subgraph C3["Capa 3 — Dominio"]
-        DB["PostgreSQL\nclients · client_users · conversations · messages\n─────────────────────────────────────\nSource of truth · tenant config · perfil · historial\nDecide: nada — es ground truth"]
+        DB["PostgreSQL<br/>clients · client_users · conversations · messages<br/>─────────────────────────────────────<br/>Source of truth · tenant config · perfil · historial<br/>Decide: nada — es ground truth"]
     end
     C2 -- directiva del turno --> C1
     C1 -- extracted_data propuesto --> C2
@@ -37,42 +72,45 @@ graph TB
 
 ---
 
-## Ubicación en el espacio de arquitecturas
+## El viaje de un mensaje (n8n orquesta)
 
-Para ubicar esto frente a otros sistemas conversacionales:
-
-```mermaid
-quadrantChart
-    title Espacio de arquitecturas conversacionales
-    x-axis Baja especificidad de dominio --> Alta especificidad de dominio
-    y-axis Baja autonomía del LLM --> Alta autonomía del LLM
-    Agentes ReAct / AutoGPT: [0.18, 0.92]
-    Bland AI / ElevenLabs Conversational: [0.50, 0.72]
-    Sales AI Agent ★ tú estás aquí: [0.85, 0.48]
-    Dialogflow / Watson / Rasa NLU: [0.82, 0.18]
-```
-
-**Lo que tenemos NO es un agente clásico** (estilo ReAct/AutoGPT). En la literatura más cercana, este patrón se conoce como **information-state dialogue manager** (Larsson & Traum, 2000) — un manejador de diálogo cuyo estado es la información acumulada — modernizado con un LLM haciendo NLU/NLG. Comercialmente, el primo más cercano es **Rasa CALM**.
-
----
-
-## El DAG de close_sale
+Cuando llega un webhook, primero el workflow `master` decide **de qué negocio** es el mensaje (por el número de WhatsApp que lo recibió) y lo enruta al workflow de ese cliente:
 
 ```mermaid
-graph TD
-    A["📦 product_matched\nproduct_id"]
-    B["👤 lead_qualified\nfull_name · phone"]
-    C["🏠 shipping_info_collected\nshipping_address · shipping_city"]
-    D["✅ user_confirmed\nuser_confirmation\n⚡ gate: requiere los 4 anteriores"]
-    E["💳 payment_confirmed\npayment_confirmation\n⚡ gate: requiere user_confirmed + phone + addr"]
-    F(["🤝 auto-escalate → human_handoff"])
-
-    A --> B --> C --> D --> E --> F
+flowchart LR
+    WH["📥 Webhook de Chakra"] --> SW{"¿Qué número<br/>de negocio?"}
+    SW -->|Café Arenillo| CA["workflow<br/>cafe_arenillo_v2"]
+    SW -->|max_natural| MN["workflow<br/>max_natural"]
+    SW -->|desconocido| X(["⚠️ sin ruta<br/>(no responde)"])
 ```
 
-Cada checkpoint del DAG representa **suficiencia de información**, no una acción del bot. La diferencia es importante: "el bot dijo X" no es lo mismo que "el sistema sabe X". El DAG opera sobre lo segundo.
+Dentro del workflow del cliente ocurre toda la lógica del turno. Fíjate en los tres **cortes** (rombos) donde el sistema puede decidir **no** responder — eso es deliberado, es "el backend gobierna" en acción:
 
-**Los DAG gates** son la innovación operacional que distingue este sistema de los DAGs académicos (PPDPP, ChatSOP). Cuando el LLM propone un slot prematuramente — por ejemplo, marcar `user_confirmation=true` antes de tener dirección — el gate lo rechaza, registra un warning, pero **la respuesta del LLM al usuario igual se envía**. La conversación nunca se rompe; solo no se persiste el dato prematuro. Esa propiedad de fail-safe es lo que vuelve confiable el sistema.
+```mermaid
+flowchart TD
+    START(["Mensaje ya enrutado<br/>al cliente"]) --> M1{"¿Trae texto?"}
+    M1 -->|"no · es un status"| STOP1(["⏹️ Stop"])
+    M1 -->|sí| ING["① POST /ingest/message<br/>el backend arma el contexto"]
+    ING --> SR{"¿should_respond?"}
+    SR -->|"no · handoff o closed"| STOP2(["⏹️ Stop — no interrumpe<br/>al humano"])
+    SR -->|sí| LLMCALL["🧠 Llama al LLM<br/>1 vez, sin tools"]
+    LLMCALL --> ACT["② POST /agent/action<br/>el backend valida"]
+    ACT --> AP{"¿approved?"}
+    AP -->|sí| SEND["📤 Responde por WhatsApp"]
+    AP -->|"no · suprimido"| ESC{"¿Escalado?"}
+    SEND --> IMG{"¿Manda foto<br/>del producto?"}
+    IMG -->|sí| SIMG["🖼️ Envía imagen"]
+    IMG -->|no| ESC
+    SIMG --> ESC
+    ESC -->|sí| OWN["Avisa al dueño"]
+    ESC -->|no| NOT{"¿Avisar<br/>al operador?"}
+    OWN --> NOT
+    NOT -->|venta lista| TGB["📲 Telegram + botón<br/>Confirmar pago"]
+    NOT -->|loop detectado| TGS["📲 Telegram · aviso simple"]
+    NOT -->|no| ENDN(["fin del turno"])
+```
+
+**La lección de los rombos**: un chatbot ingenuo responde a *todo*. Este sistema tiene tres puntos donde frena a propósito — no es texto, el humano ya tomó la conversación, o el backend rechazó la respuesta. Callar en el momento correcto es tan importante como responder bien.
 
 ---
 
@@ -116,9 +154,42 @@ sequenceDiagram
 
 ---
 
-## Estado de información en tres niveles
+## El DAG de close_sale
 
-Una conversación tiene tres tipos de información distintos, cada uno con su lugar:
+```mermaid
+graph TD
+    A["📦 product_matched<br/>product_id"]
+    B["👤 lead_qualified<br/>full_name · phone"]
+    C["🏠 shipping_info_collected<br/>shipping_address · shipping_city"]
+    D["✅ user_confirmed<br/>user_confirmation<br/>⚡ gate: requiere los 4 anteriores"]
+    E["💳 payment_confirmed<br/>payment_confirmation<br/>⚡ gate: requiere user_confirmed + phone + addr"]
+    F(["🤝 auto-escalate → human_handoff"])
+
+    A --> B --> C --> D --> E --> F
+```
+
+Cada checkpoint del DAG representa **suficiencia de información**, no una acción del bot. La diferencia es importante: "el bot dijo X" no es lo mismo que "el sistema sabe X". El DAG opera sobre lo segundo.
+
+**Los DAG gates** son la innovación operacional que distingue este sistema de los DAGs académicos (PPDPP, ChatSOP). Cuando el LLM propone un slot prematuramente — por ejemplo, marcar `user_confirmation=true` antes de tener dirección — el gate lo rechaza, registra un warning, pero **la respuesta del LLM al usuario igual se envía**. La conversación nunca se rompe; solo no se persiste el dato prematuro. Esa propiedad de fail-safe es lo que vuelve confiable el sistema.
+
+---
+
+## Cómo se recolectan los datos
+
+Este es el corazón de "el backend gobierna". Cada dato que el cliente menciona hace este viaje antes de considerarse real:
+
+```mermaid
+flowchart LR
+    MSG["🗣️ Cliente:<br/>'soy Juan Pérez,<br/>en Manizales'"] --> LLM["🧠 El LLM extrae<br/>extracted_data:<br/>full_name, shipping_city"]
+    LLM --> GATE{"🚦 DAG gate<br/>¿es admisible<br/>ahora y válido?"}
+    GATE -->|"rechazado<br/>(prematuro / inválido)"| WARN["⚠️ warning<br/>no se guarda —<br/>pero igual responde"]
+    GATE -->|aceptado| CTX["🛒 extracted_context<br/>carrito de esta<br/>conversación · 24h"]
+    CTX -->|"dato estable<br/>(nombre, dirección…)"| PROF["👤 client_users.profile<br/>perfil permanente<br/>entre conversaciones"]
+```
+
+La idea clave: **el LLM propone, el gate filtra, y solo lo aceptado se persiste**. Un teléfono con formato basura o una confirmación de pago sin dirección nunca entran a la base de datos, aunque el LLM los haya "creído".
+
+Una conversación tiene entonces tres tipos de información distintos, cada uno con su lugar:
 
 | Tipo | Descripción | Dónde vive | Persistencia |
 |------|-------------|------------|--------------|
@@ -127,6 +198,146 @@ Una conversación tiene tres tipos de información distintos, cada uno con su lu
 | **Contexto efímero** | Inferencias del último turno | Transitorio en memoria del LLM | Por turno |
 
 > **Limitación conocida**: si un cliente abandona la venta a mitad del flujo y vuelve días después, el estado de venta se pierde porque vive en `extracted_context` de la conversación expirada. El perfil persiste pero el carrito no. Resolverlo requiere una entidad nueva (`purchase_intents`) — pendiente en roadmap.
+
+---
+
+## El modelo de datos (el grafo de tablas)
+
+Seis tablas, todas colgando del tenant (`clients`). Así se relacionan:
+
+```mermaid
+erDiagram
+    clients      ||--o{ client_users  : "tiene clientes"
+    clients      ||--o{ products      : "vende"
+    clients      ||--o{ conversations : "atiende"
+    client_users ||--o{ conversations : "participa en"
+    conversations ||--o{ messages     : "contiene"
+    clients      ||--o{ audit_log     : "registra eventos"
+
+    clients {
+        uuid id PK
+        string name
+        jsonb business_rules "config por cliente"
+        text system_prompt_template "la voz del negocio"
+    }
+    client_users {
+        uuid id PK
+        uuid client_id FK
+        string phone_number
+        jsonb profile "datos permanentes del cliente"
+    }
+    products {
+        uuid id PK
+        uuid client_id FK
+        string name
+        int price
+    }
+    conversations {
+        uuid id PK
+        uuid client_id FK
+        string state "active / human_handoff / closed"
+        jsonb extracted_context "el carrito de 24h"
+        int strategy_version "anti-staleness"
+    }
+    messages {
+        uuid id PK
+        uuid conversation_id FK
+        string direction "inbound / outbound"
+        string chakra_message_id "UNIQUE · idempotencia"
+    }
+    audit_log {
+        uuid id PK
+        uuid client_id FK
+        string event "append-only"
+    }
+```
+
+**Regla de oro del schema**: toda tabla que ve datos de un tenant tiene `client_id NOT NULL`, y toda query filtra por él. Los dos JSONB (`profile` y `extracted_context`) son donde vive casi toda la "memoria" del sistema.
+
+---
+
+## La máquina de estados de la conversación
+
+Una conversación solo puede estar en uno de **tres** estados. Este grafo manda sobre si el bot habla o se calla:
+
+```mermaid
+stateDiagram-v2
+    [*] --> active: llega el primer mensaje
+    active --> human_handoff: DAG completo, o loop detectado
+    human_handoff --> active: el cliente sigue y el operador no cerró
+    active --> closed: operador confirma pago
+    human_handoff --> closed: operador confirma pago
+    closed --> [*]
+
+    note right of active
+        El bot responde normalmente
+    end note
+    note right of human_handoff
+        El bot se calla —
+        manda un humano
+    end note
+    note right of closed
+        Terminal. Si el cliente
+        vuelve a escribir, nace
+        una conversación nueva
+        en active
+    end note
+```
+
+Toda conversación nace en `active`. Se auto-escala a `human_handoff` por dos vías: (1) el DAG de venta se completó (cliente confirmó el pedido), o (2) el **circuit breaker** detectó un loop (el bot repitió el mismo mensaje 3 veces). A `closed` solo se llega cuando el **operador humano** confirma que el pago es real.
+
+---
+
+## El lazo del operador humano (ADR-009)
+
+El sistema no cierra ventas solo — un humano confirma el pago. Ese ida y vuelta ocurre por Telegram, sin que nadie tenga que abrir un panel:
+
+```mermaid
+sequenceDiagram
+    participant B as Backend
+    participant N as n8n
+    participant T as Telegram
+    participant Op as 🧑‍💼 Operador
+
+    Note over B: El cliente confirmó el pedido<br/>(checkpoint user_confirmed)
+    B-->>N: side_effect checkpoint_completed:user_confirmed
+    N->>T: Aviso "venta lista" + botón [Confirmar pago]
+    Op->>T: pulsa el botón
+    T->>N: callback_query · confirm:conversation_id
+    N->>N: Valida que quien pulsa sea el operador (fail-closed)
+    N->>B: POST /api/v1/operator/confirm-payment
+    B->>B: marca payment_confirmation · registra la venta · cierra
+    B-->>N: 200 confirmed (idempotente)
+    N->>T: "Pago confirmado ✅"
+```
+
+Dos detalles de seguridad: el endpoint del operador usa **su propio token** (el token de servicio no lo abre, y viceversa), y n8n valida que el `chat_id` de quien pulsa el botón sea el del operador autorizado — si no, no hace nada (*fail-closed*).
+
+---
+
+## Concurrencia y consistencia
+
+**Problema**: WhatsApp manda ráfagas. Un cliente que escribe "hola" + "quiero comprar" + "café molido" en 3 segundos genera 3 webhooks paralelos. Si los procesamos concurrentemente, el LLM puede ver contextos inconsistentes.
+
+```mermaid
+sequenceDiagram
+    participant C as Cliente
+    participant B as Backend
+    C->>B: "hola"  (t=0s)
+    C->>B: "quiero comprar"  (t=2s)
+    C->>B: "café molido"  (t=3s)
+    Note over B: cada mensaje espera 5s (debounce);<br/>los dos primeros ceden el turno
+    B-->>C: 1 sola respuesta que ya vio los 3 mensajes
+```
+
+**Soluciones aplicadas**:
+
+1. **Advisory lock** por `conversation_id`: `pg_advisory_xact_lock(hash(conv_id))` serializa los mensajes de la misma conversación dentro de la transacción. Se libera automáticamente con commit/rollback.
+2. **Debounce de 5 segundos**: tras commitear el primer mensaje, el backend espera 5s y verifica si llegó otro. Si sí, este turno no responde — deja que el siguiente mensaje (que ahora ve los anteriores) genere la respuesta.
+3. **Idempotencia por `chakra_message_id`**: webhook que llega dos veces con el mismo ID se reconoce como duplicado.
+4. **strategy_version**: protege contra que `/agent/action` opere sobre contexto que cambió entre las dos llamadas (ver ADR-003).
+
+> **Limitación conocida**: el `asyncio.sleep(5)` durante la transacción mantiene el connection pool ocupado. Bajo carga sostenida puede saturar el pool. Es deuda técnica priorizada.
 
 ---
 
@@ -147,18 +358,22 @@ El `system_prompt_template` también es por cliente — cada negocio tiene su pr
 
 ---
 
-## Concurrencia y consistencia
+## Ubicación en el espacio de arquitecturas
 
-**Problema**: WhatsApp manda ráfagas. Un cliente que escribe "hola" + "quiero comprar" + "café molido" en 3 segundos genera 3 webhooks paralelos. Si los procesamos concurrentemente, el LLM puede ver contextos inconsistentes.
+Para ubicar esto frente a otros sistemas conversacionales:
 
-**Soluciones aplicadas**:
+```mermaid
+quadrantChart
+    title Espacio de arquitecturas conversacionales
+    x-axis Baja especificidad de dominio --> Alta especificidad de dominio
+    y-axis Baja autonomía del LLM --> Alta autonomía del LLM
+    Agentes ReAct / AutoGPT: [0.18, 0.92]
+    Bland AI / ElevenLabs Conversational: [0.50, 0.72]
+    Sales AI Agent ★ tú estás aquí: [0.85, 0.48]
+    Dialogflow / Watson / Rasa NLU: [0.82, 0.18]
+```
 
-1. **Advisory lock** por `conversation_id`: `pg_advisory_xact_lock(hash(conv_id))` serializa los mensajes de la misma conversación dentro de la transacción. Se libera automáticamente con commit/rollback.
-2. **Debounce de 5 segundos**: tras commitear el primer mensaje, el backend espera 5s y verifica si llegó otro. Si sí, este turno no responde — deja que el siguiente mensaje (que ahora ve los anteriores) genere la respuesta.
-3. **Idempotencia por `chakra_message_id`**: webhook que llega dos veces con el mismo ID se reconoce como duplicado.
-4. **strategy_version**: protege contra que `/agent/action` opere sobre contexto que cambió entre las dos llamadas (ver ADR-003).
-
-> **Limitación conocida**: el `asyncio.sleep(5)` durante la transacción mantiene el connection pool ocupado. Bajo carga sostenida puede saturar el pool. Es deuda técnica priorizada.
+**Lo que tenemos NO es un agente clásico** (estilo ReAct/AutoGPT). En la literatura más cercana, este patrón se conoce como **information-state dialogue manager** (Larsson & Traum, 2000) — un manejador de diálogo cuyo estado es la información acumulada — modernizado con un LLM haciendo NLU/NLG. Comercialmente, el primo más cercano es **Rasa CALM**.
 
 ---
 


### PR DESCRIPTION
## Qué hace

Enriquece `sales-ai-docs/docs/architecture/overview.md` con **muchos más diagramas** y lenguaje simple, a partir de todo lo construido (ADR-009, workflows n8n as-built, esquema de DB). Pasa de 5 a **12 diagramas Mermaid** (GitHub los renderiza nativo).

## Diagramas nuevos

- **Mapa de comunicación** — quién habla con quién (Cliente ↔ Chakra ↔ n8n ↔ Backend ↔ LLM/DB/Key Vault + operador Telegram), con nota de resiliencia.
- **El viaje de un mensaje** — enrutamiento del `master` por número de negocio + el grafo del workflow del cliente con los **tres cortes** (no-texto / should_respond / approved) y la rama de escalamiento.
- **Máquina de estados** de la conversación (`active → human_handoff → closed`).
- **Lazo del operador humano** (ADR-009) — secuencia del botón "Confirmar pago" por Telegram.
- **Recolección de datos** — cómo un dato viaja: LLM → DAG gate → `extracted_context` (24h) → `profile` (permanente).
- **ER de las 6 tablas** — el grafo del modelo de datos.
- **Ráfagas / debounce** — cómo 3 mensajes en 3s se vuelven 1 respuesta.

## Diagramas conservados

Las 3 capas, el DAG de close_sale, el patrón de dos llamadas y el quadrant chart siguen; se unificaron los saltos de línea a `<br/>` para render limpio.

## Verificación

- 12 bloques `mermaid`, fences balanceados, todos con tipo de diagrama válido.
- Etiquetas con caracteres especiales entre comillas para evitar errores de parseo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)