### PR TITLE
fix(pago): el operador es la única autoridad del pago (venta duplicada)

### DIFF
--- a/migrations/versions/011_remove_payment_confirmation_from_prompt.sql
+++ b/migrations/versions/011_remove_payment_confirmation_from_prompt.sql
@@ -1,0 +1,43 @@
+-- Migration 011: quitar `payment_confirmation` de la lista de extracción del prompt
+--
+-- Contexto (bug de venta duplicada, e2e del 2026-07-20, conversación 9635…bce7):
+-- la venta se registró DOS veces en client_users.profile porque existían dos
+-- autoridades vivas sobre el mismo hecho. ADR-009 construyó la correcta (el
+-- operador revisa el comprobante y pulsa el botón → POST /operator/confirm-payment)
+-- pero nunca retiró la vieja: el cliente escribía "ya pagué", el LLM proponía
+-- `payment_confirmation` en extracted_data y el backend registraba la venta.
+--
+-- El backend ya no acepta esa propuesta (agent_action.py: OPERATOR_ONLY_FIELDS).
+-- Esta migración cierra el otro extremo: dejar de PEDÍRSELO al LLM. Es la
+-- alternativa B que el propio ADR-009 rechazó ("'ya pagué' no es prueba de pago"),
+-- todavía escrita en el prompt de producción (venía de 006, reafirmada en 009:217).
+--
+-- Qué NO toca, a propósito: el comportamiento de cobro sigue igual. Las secciones
+-- FLUJO DE COMPRA (pasos 5-6), COMPROBANTE DE PAGO y HANDOFF HUMANO quedan
+-- intactas — el bot sigue pidiendo el comprobante y despidiéndose con calidez.
+-- Lo único que se retira es la instrucción de EMITIR la clave en extracted_data.
+--
+-- Edición quirúrgica (no re-escribe el template): borra exactamente la línea de
+-- `payment_confirmation` de la sección "EXTRACCIÓN DE DATOS (extracted_data)".
+-- Idempotente: el guard LIKE hace que una re-ejecución sea no-op.
+--
+-- Aplicar en n8n el cambio gemelo (nodo "Build LLM Prompt" del workflow
+-- cafe_arenillo_v2: quitar payment_confirmation de "Valid extracted_data keys").
+--
+-- No schema change.
+--
+-- Applied:
+
+UPDATE clients
+   SET system_prompt_template = REPLACE(
+           system_prompt_template,
+           E'- `payment_confirmation`: true cuando el cliente envíe el comprobante de pago.\n',
+           ''
+       )
+ WHERE id = '00000000-0000-0000-0000-000000000001'
+   AND system_prompt_template LIKE '%`payment_confirmation`%';
+
+-- Verificación (debe devolver 0):
+--   SELECT count(*) FROM clients
+--    WHERE id = '00000000-0000-0000-0000-000000000001'
+--      AND system_prompt_template LIKE '%payment_confirmation%';

--- a/sales-ai-docs/docs/briefs/impl-brief-fix-venta-duplicada.md
+++ b/sales-ai-docs/docs/briefs/impl-brief-fix-venta-duplicada.md
@@ -1,0 +1,169 @@
+# Brief — Fix venta duplicada: el operador como única autoridad del pago (A+B+C)
+
+> **Sistema REAL (no greenfield)**: backend FastAPI en prod (Azure Container Apps,
+> imagen = origin/main HEAD, PR #56, 2026-07-21), Postgres 6 tablas post-007, ADR-009
+> (lazo de handoff) mergeado y probado e2e. Edita código vivo. Toca DB (migración) y
+> n8n vivo (un nodo). NO rediseña.
+>
+> **Disciplina**: se ejecuta en DOS FASES separadas (ver abajo). Cada fase: plan por
+> archivo antes de codear, espera confirmación del humano, un commit con su test, suite
+> verde. Rama nueva desde main. NO desplegar sin OK explícito.
+>
+> ⚠️ **Nota de working copy**: la copia local puede estar en una rama vieja
+> (`docs/overview-arquitectura-diagramas`, pre-ADR-009, sin `operator.py`). NO cites
+> líneas de ahí. Trabaja sobre `origin/main` actualizado (haz pull/fetch primero).
+
+---
+
+## Contexto: qué pasó y por qué
+
+**El síntoma**: en el e2e del lazo de handoff (2026-07-20, conversación 9635…bce7), la
+venta se registró DOS VECES en el profile del cliente. `purchase_count: 2`, dos
+registros idénticos (quantity: 2, total: 80000, mismo product_id, mismo
+conversation_id), separados 67 segundos.
+
+**La causa raíz**: existen DOS caminos vivos que registran una venta como pagada, y
+ADR-009 solo construyó el nuevo sin desactivar el viejo.
+
+- **Camino nuevo (correcto, ADR-009)**: operador revisa el comprobante → pulsa botón en
+  Telegram → `POST /operator/confirm-payment` → marca pago, registra venta, cierra.
+- **Camino viejo (legado, debió morir con ADR-009 pero sigue armado)**: el cliente
+  escribe "ya pagué" (texto, sin comprobante) → el LLM propone `payment_confirmation` en
+  `extracted_data` → el gate lo acepta (solo valida precondiciones, NO el origen) →
+  `agent_action` ejecuta su camino legado y registra la venta.
+
+**La secuencia exacta del bug** (del audit_log, e2e 20-jul):
+
+| hora UTC | evento | efecto |
+|----------|--------|--------|
+| 22:43:22 | agent_turn · checkpoint_completed:user_confirmed | dispara aviso Telegram |
+| 22:45:38 | agent_turn · context_updated:[payment_confirmation] + escalated | **venta #1 (LLM)** |
+| 22:46:45 | sale_closed · actor_type=operator | **venta #2 (operador)** |
+
+**Por qué la idempotencia no lo atrapó**: el guard del endpoint es
+`state == "closed" and payment_confirmation` (`confirm_payment.py:66`). Está atado al
+estado `closed`. Pero el camino viejo del LLM deja la conversación en `human_handoff`,
+NO en `closed`. Así que cuando el operador pulsa el botón, el endpoint ve estado ≠
+closed, concluye "no confirmada aún" y escribe la segunda venta. La idempotencia mira el
+estado equivocado.
+
+**El principio violado**: esto es exactamente la Alternativa B que ADR-009 rechazó
+("el LLM no puede marcar el pago; 'ya pagué' no es prueba"). El docstring de
+`confirm_payment.py:6` ya dice "The LLM must never propose it". El ADR movió la VERDAD al
+operador pero nunca RETIRÓ la autoridad del camino viejo. Hoy coexisten dos autoridades
+para el mismo hecho, y ambas escriben. El objetivo del fix: **hacer que el operador sea
+la ÚNICA autoridad del pago, en código, no solo en el documento.**
+
+## Ubicaciones confirmadas (citadas sobre origin/main)
+
+- `agent_action.py:43` — `payment_confirmation` es un STRATEGY_FIELD normal.
+- `agent_action.py:177-181` — gate P3 valida precondiciones, no origen.
+- `agent_action.py:373` — `payment_just_confirmed = "payment_confirmation" in strategy_accepted`
+- `agent_action.py:380-387, 561-572, 391` — el camino que registra la venta y sube
+  lifecycle cuando el LLM propuso el pago.
+- `confirm_payment.py:66` — guard de idempotencia atado a `state == "closed"`.
+- `confirm_payment.py:6` — docstring que ya declara el invariante correcto.
+- **Prompt, lugar 1 (DB)**: `clients.system_prompt_template` (texto de
+  `009_humanize_prompt_after_apr30_review.sql:217`): instruye
+  "`payment_confirmation`: true cuando el cliente envíe el comprobante".
+- **Prompt, lugar 2 (n8n vivo)**: workflow `cafe_arenillo_v2` (xKtfVQsyYWkwQta9), nodo
+  "Build LLM Prompt": lista `payment_confirmation` como key válida de extracción. Mismo
+  texto en el export `n8n_workflow/cafe_arenillo_v2.json:403`.
+
+---
+
+## El fix: A + B + C
+
+**A — desactivar el camino LLM→venta en el backend.** En `agent_action.py`, hacer que
+una propuesta de `payment_confirmation` proveniente del LLM NO sea tratada como venta
+consumada. El pago solo se registra vía el endpoint del operador. Concretamente: sacar
+`payment_confirmation` de la vía que dispara `_merge_profile(payment_just_confirmed=True)`
+/ el registro de compra / el auto-escalate por pago. Decide con el humano el mecanismo
+exacto (¿excluir la key del STRATEGY_FIELD?, ¿ignorarla en el punto :373?) y propónlo
+antes de codear — pero el invariante es: **el LLM proponiendo payment_confirmation NO
+registra venta ni sube lifecycle.**
+
+**B — limpiar el prompt en sus DOS lugares.**
+- B1 (DB): migración `011_remove_payment_confirmation_from_prompt.sql` que edita
+  `clients.system_prompt_template` para quitar la instrucción que le pide al LLM emitir
+  `payment_confirmation`. (Migración nueva, secuencial, no se modifica ninguna aplicada.)
+- B2 (n8n vivo): editar el nodo "Build LLM Prompt" de `cafe_arenillo_v2` para quitar
+  `payment_confirmation` de las "Valid extracted_data keys". **FASE 2 — toca n8n vivo.**
+
+**C — desacoplar la idempotencia del endpoint del estado.** En `confirm_payment.py`, el
+guard de idempotencia debe detectar "pago ya registrado / ya en contexto" SIN depender de
+que la conversación esté en `closed`. Así, si por cualquier razón el pago ya está en el
+contexto, el endpoint no lo duplica. C deja de ser parche del síntoma y pasa a ser el
+cinturón de seguridad del invariante "una sola venta por confirmación".
+
+---
+
+## Secuencia en DOS FASES (por riesgo)
+
+**FASE 1 — Backend (terreno fuerte, testeable, NO toca n8n):** A + C + migración B1.
+Esto solo ya corta la mayoría del bug: con A, aunque el prompt aún pida el campo, el
+backend ignora la propuesta del LLM y no registra la venta. Un commit. Deja el fix de
+fondo a salvo en main antes de tocar el workflow vivo.
+
+**FASE 2 — n8n (mayor riesgo, sesión aparte):** B2 (editar el nodo del workflow).
+Limpieza defensiva. Requiere **export del workflow ANTES y DESPUÉS**, y verificación con
+conversación de prueba. Es lo último porque toca producción viva y el fix de Fase 1 ya
+protege el invariante sin esto.
+
+> Partir así da una victoria verificable en backend antes de tocar n8n. Si algo sale mal
+> en n8n, el fix de fondo ya está en main.
+
+---
+
+## Tests obligatorios (el contrato que evita que el bug reviva)
+
+En `tests/services/test_agent_action.py` y `tests/services/test_confirm_payment.py`:
+
+1. **Invariante central (A)**: un turno donde el LLM propone `payment_confirmation` con
+   todas las precondiciones presentes → NO se registra venta en el profile, NO sube
+   lifecycle, NO se dispara auto-escalate por pago. (Fija que el LLM no cierra ventas.)
+2. **El operador sí registra (no romper el camino bueno)**: llamada al endpoint
+   `confirm-payment` autorizada → SÍ registra la venta, sube lifecycle, cierra. Sin
+   cambios respecto a ADR-009.
+3. **Idempotencia desacoplada (C)**: con el pago ya en contexto (simulando el caso viejo)
+   y la conversación en `human_handoff` (NO closed) → el endpoint NO escribe una segunda
+   venta. Este es el test que fija el fix C.
+4. **No duplicación e2e-lógico**: simular la secuencia del bug (LLM propone pago, luego
+   operador confirma) → resultado final = UNA sola venta en el profile, purchase_count=1.
+5. **Regresión**: los tests de P2/P3/P8/ADR-009 siguen verdes. El shape de purchases
+   (quantity/total, contrato P2) intacto.
+
+---
+
+## Limpieza de datos (PASO SEPARADO, después del fix, en manos del humano)
+
+NO es parte del fix de código. Es un UPDATE deliberado a producción sobre una fila
+conocida: `client_user 15d89710-…` ("Sebastian", tel ***8477 = número de prueba del
+humano). Estado sucio actual: `purchase_count: 2`, dos registros duplicados. Objetivo:
+`purchase_count: 1` con el registro legítimo (el del operador, 22:46:45.509); eliminar el
+registro del LLM (22:45:38.117).
+
+- Se hace DESPUÉS de mergear el fix (si se limpia antes y se vuelve a probar, se re-ensucia).
+- Es un UPDATE puntual, no un cambio amplio. El humano lo ejecuta o lo aprueba
+  explícitamente. Code NO lo hace sin luz verde.
+
+---
+
+## Cierre y registro
+
+- Fase 1: un commit (A+C+B1) con sus tests, verde. Fase 2: edición n8n con export
+  antes/después. Reportar archivo:línea de cada cambio.
+- Actualizar las **notas as-built de ADR-009** (el PR sigue editable / o nota nueva si ya
+  se mergeó): registrar que el camino legado LLM→payment se desactivó, cerrando la brecha
+  entre la decisión del ADR (Alternativa B rechazada) y el código.
+- NO desplegar sin OK. NO tocar north-star (delay humano, ADR-010 detección de bots
+  siguen en diseño, no se implementan aquí).
+
+## Definition of done
+
+- El LLM proponiendo `payment_confirmation` NO registra venta (test 1 verde).
+- El operador sigue siendo la única vía que registra venta (test 2 verde).
+- El endpoint no duplica aunque el pago esté en contexto en estado no-closed (test 3).
+- El prompt ya no pide `payment_confirmation` en NINGUNO de sus dos lugares (DB + n8n).
+- Datos de prueba limpios (paso separado, aprobado por el humano).
+- Regresión completa verde; contrato P2 del shape de purchases intacto.

--- a/sales-ai-docs/docs/decisions/ADR-009-handoff-closure-loop.md
+++ b/sales-ai-docs/docs/decisions/ADR-009-handoff-closure-loop.md
@@ -1,6 +1,6 @@
 # ADR-009 — Cierre del lazo de handoff humano (confirmación de pago, notificación y corte)
 
-- **Estatus**: Propuesto
+- **Estatus**: Aceptado — implementado (PR #54, e2e 2026-07-20). Ver "Notas as-built" al final.
 - **Fecha**: 2026-07-19
 - **Decididores**: Sebastian + cofounder/principal architect
 - **Origen**: postmortem de la primera venta cerrada (`docs/postmortems/`), que reveló
@@ -148,6 +148,55 @@ por conversación nueva ya está soportada.
 
 Cada paso: un commit, su test donde aplique, verificado antes del siguiente. Los pasos 1-3
 son backend (tu terreno fuerte); 2 toca n8n; 4-5 son la pieza nueva de Telegram.
+
+## Notas as-built (2026-07-31) — la autoridad vieja también había que retirarla
+
+Implementado en PR #54 (endpoint + auth + Telegram + corte n8n) y probado e2e el
+2026-07-20. Ese e2e destapó lo que a este ADR le faltó: **movió la verdad del pago al
+operador pero nunca RETIRÓ la autoridad del camino viejo**. Quedaron dos autoridades vivas
+sobre el mismo hecho y ambas escribieron — la venta se registró DOS veces en el profile
+(conversación `9635…bce7`, `purchase_count: 2`, dos registros idénticos separados 67s:
+22:45:38 el del LLM, 22:46:45 el del operador). Era exactamente la **alternativa B que
+este ADR rechazó**, siguiendo viva en el código y en el prompt.
+
+La idempotencia del endpoint tampoco lo atrapó: su guard era `state == "closed" AND
+payment_confirmation`, y el camino viejo dejaba la conversación en `human_handoff`. Miraba
+el estado, no el hecho.
+
+Fix (rama `fix/venta-duplicada`, brief `docs/briefs/impl-brief-fix-venta-duplicada.md`):
+
+1. **`OPERATOR_ONLY_FIELDS`** en `agent_action.py`: un `payment_confirmation` propuesto por
+   el LLM se descarta SIEMPRE — sin gate, sin precondiciones que discutir — con side effect
+   visible `warning:payment_claim_ignored`. Un turno del agente ya no registra venta ni
+   promueve a `customer`. Esto reemplaza el gate P3 (PR #48), que quedó sin sentido: su
+   escenario ahora es imposible por una razón más fuerte.
+2. **Idempotencia por el hecho**: `evaluate_confirmation` decide por `payment_confirmation`
+   en contexto, sin mirar el estado.
+3. **Migración `011`**: saca la instrucción de emitir `payment_confirmation` del
+   `system_prompt_template`. El comportamiento de cobro no cambia (el bot sigue pidiendo el
+   comprobante y despidiéndose); solo deja de pedírsele la clave.
+4. **Guard `state == "active"`** en el auto-escalate: `confirm_payment` no sube
+   `strategy_version`, así que un turno en vuelo pasaba el chequeo de staleness, veía el
+   pago del operador (`all_complete`) y **resucitaba la conversación cerrada** a
+   `human_handoff` — donde la ventana de 24h del ingest atrapaba el siguiente mensaje del
+   cliente en una conversación que el bot no debe contestar.
+
+**Invariante que queda escrito en código**: `payment_confirmation` presente en
+`extracted_context` significa exactamente una cosa — un operador lo confirmó.
+
+**Consecuencia de diseño aceptada**: el turno del agente ya no escala por venta completa.
+Tras la confirmación del pedido la conversación sigue en `active` (el bot acompaña, el
+prompt ya lo hace despedirse) hasta que el operador pulsa el botón y cierra. El único
+escalamiento automático que queda es el circuit breaker. Se descartó escalar con el claim
+del LLM: un "ya pagué" falso o alucinado dejaría la conversación congelada sin vía de
+retorno (no existe endpoint `human_handoff → active`).
+
+**Pendiente al cerrar esta nota**: aplicar la `011` en prod; quitar `payment_confirmation`
+de las "Valid extracted_data keys" del nodo "Build LLM Prompt" en `cafe_arenillo_v2`
+(Fase 2, n8n vivo); limpiar la fila sucia del e2e. Detalle menor de la piel: en el caso
+legado (pago en contexto con la conversación aún en `human_handoff`) el endpoint responde
+`already_confirmed` sin cerrar, y el mensaje de Telegram dice "ya estaba confirmada y
+cerrada" — solo aplica a filas anteriores a este fix.
 
 ## Cuándo revisar
 

--- a/sales_agent_api/app/services/agent_action.py
+++ b/sales_agent_api/app/services/agent_action.py
@@ -5,14 +5,15 @@ After the LLM produces a response, n8n calls this service to:
      identical outbound, escalate to human_handoff and suppress it
      (approved=False, empty final_response_text) instead of persisting.
   1. Persist strategy-relevant extracted_data into conversation.extracted_context
-     (with DAG gates to enforce data order: user_confirmation needs
-     name+phone+address+city; payment_confirmation needs user_confirmation+phone+address)
+     (DAG gate: user_confirmation needs name+phone+address+city). A
+     payment_confirmation proposed by the LLM is DROPPED — confirming a payment
+     is the operator's authority alone (ADR-009, see OPERATOR_ONLY_FIELDS).
   2. Merge stable customer facts back into client_users.profile (persistent).
-  3. On payment_confirmation, bump profile.purchase_count + append purchase record.
-  4. Auto-escalate to human_handoff when all purchase data is collected.
-  5. Apply a proposed_transition if the LLM sends one (rare).
-  6. Persist the outbound message with AI metadata.
-  7. Write audit log entries.
+     Never a purchase record: an agent turn NEVER records a sale.
+  3. Auto-escalate to human_handoff when all purchase data is collected.
+  4. Apply a proposed_transition if the LLM sends one (rare).
+  5. Persist the outbound message with AI metadata.
+  6. Write audit log entries.
 """
 from __future__ import annotations
 
@@ -42,6 +43,15 @@ STRATEGY_FIELDS = {
     "shipping_address", "shipping_city",
     "user_confirmation", "payment_confirmation",
 }
+
+# Checkpoints the LLM may NEVER propose. payment_confirmation stays a DAG
+# checkpoint (the engine reads it from extracted_context) but its truth lives
+# outside the system — in a human looking at a receipt (ADR-009, alternative B
+# rejected: "ya pagué" is not proof). The ONLY writer is the operator endpoint
+# (confirm_payment.py). Anything the LLM proposes here is dropped in
+# compute_context_updates, so `payment_confirmation` present in
+# extracted_context means exactly one thing: an operator confirmed it.
+OPERATOR_ONLY_FIELDS = {"payment_confirmation"}
 
 # Non-DAG order details the customer volunteers (quantity, grind/roast taste).
 # Persisted to extracted_context in parallel to STRATEGY_FIELDS so the bot stops
@@ -80,9 +90,9 @@ class StaleContextError(AgentActionError):
 
 
 # DAG gate requirements — kept here so the pure selector below and the caller
-# share one source of truth.
+# share one source of truth. (There is no payment gate any more: payment is
+# never accepted from an agent turn at all — see OPERATOR_ONLY_FIELDS.)
 _USER_CONFIRMATION_REQUIRES = ("full_name", "phone", "shipping_address", "shipping_city")
-_PAYMENT_CONFIRMATION_REQUIRES = ("user_confirmation", "phone", "shipping_address")
 
 # Circuit breaker (P8): the outbound about to be sent fires the breaker when it
 # is the 3rd consecutive identical response — it equals BOTH of the two most
@@ -144,12 +154,22 @@ def compute_context_updates(
       - ``strategy_accepted``: the subset that are DAG strategy fields — drives
         profile merge + lifecycle bump in the caller. ORDER_FIELDS never appear
         here, so they can't trip the engine or the CRM lifecycle.
-      - ``rejections``: ``[{"field", "missing"}]`` for gated slots dropped
-        because their prerequisites weren't met yet.
+      - ``rejections``: ``[{"field", "missing"}]`` for slots dropped because
+        their prerequisites weren't met yet, or because the LLM has no
+        authority over them at all (OPERATOR_ONLY_FIELDS).
     """
     order_updates = {k: v for k, v in extracted_data.items() if k in ORDER_FIELDS and v}
     strategy_updates = {k: v for k, v in extracted_data.items() if k in STRATEGY_FIELDS and v}
     rejections: list[dict] = []
+
+    # Operator-only checkpoints are dropped UNCONDITIONALLY — no gate, no
+    # prerequisites to argue about (ADR-009). Done FIRST so the dropped value
+    # can never reach `merged` and count toward another slot's prerequisites.
+    # This supersedes the old payment gate (P3, PR #48): its scenario (payment
+    # riding on a same-turn user_confirmation) is now impossible a fortiori.
+    for field in sorted(OPERATOR_ONLY_FIELDS & strategy_updates.keys()):
+        del strategy_updates[field]
+        rejections.append({"field": field, "missing": ["operator_confirmation"]})
 
     # phone must be a plausible international number (E.164-lax, ADR-008):
     # 7-15 digits. Gated BEFORE merged is computed so garbage rejected this
@@ -166,19 +186,6 @@ def compute_context_updates(
         if missing:
             del strategy_updates["user_confirmation"]
             rejections.append({"field": "user_confirmation", "missing": missing})
-
-    # payment_confirmation requires user_confirmation + phone + shipping_address.
-    # Recompute merged AFTER the user_confirmation gate: a user_confirmation that
-    # was rejected THIS turn has just been dropped from strategy_updates, so it
-    # must not count toward payment's prerequisite. (A user_confirmation already
-    # persisted in current_context from a prior turn still counts — it survives
-    # in merged via the current_context spread.)
-    merged = {**current_context, **order_updates, **strategy_updates}
-    if "payment_confirmation" in strategy_updates:
-        missing = [f for f in _PAYMENT_CONFIRMATION_REQUIRES if not merged.get(f)]
-        if missing:
-            del strategy_updates["payment_confirmation"]
-            rejections.append({"field": "payment_confirmation", "missing": missing})
 
     accepted = {**order_updates, **strategy_updates}
     return accepted, strategy_updates, rejections
@@ -339,14 +346,12 @@ async def process_agent_action(
                 side_effects.append(
                     f"warning:premature_summary_missing_{'+'.join(rej['missing'])}"
                 )
-            # Likewise surface a premature payment_confirmation. This is the money
-            # step, and the human who inherits the handoff must SEE that a payment
-            # was attempted and rejected rather than have it vanish silently. Kept
-            # as a distinct string from the summary warning above.
+            # The LLM claimed a payment. It is dropped (ADR-009), but never
+            # silently: this is the money step, and the operator who decides it
+            # must SEE that the customer said "ya pagué" rather than have the
+            # claim vanish. Registering the sale remains theirs alone.
             elif rej["field"] == "payment_confirmation":
-                side_effects.append(
-                    f"warning:premature_payment_missing_{'+'.join(rej['missing'])}"
-                )
+                side_effects.append("warning:payment_claim_ignored")
             # An implausible phone (ADR-008): dropped, not persisted. The bot
             # keeps the conversation going (fail-safe) and ops sees the drop.
             elif rej["field"] == "phone":
@@ -370,33 +375,33 @@ async def process_agent_action(
             # Profile merge + CRM lifecycle bump are driven ONLY by DAG strategy
             # fields — order details (quantity/grind/roast) never move lifecycle.
             if strategy_accepted:
-                payment_just_confirmed = "payment_confirmation" in strategy_accepted
-                product_price = None
-                if payment_just_confirmed:
-                    product_price = await _fetch_product_price(
-                        session, client_id, new_context.get("product_id")
-                    )
-                # Merge stable customer facts into the persistent profile
+                # Facts about the person only. `payment_just_confirmed=False` is
+                # not a default here, it is the invariant: an agent turn never
+                # records a sale and never promotes to 'customer'. Both belong to
+                # the operator endpoint (confirm_payment.py — ADR-009).
                 await _merge_profile(
                     session,
                     client_user_id=conversation.client_user_id,
                     extracted_context=new_context,
-                    payment_just_confirmed=payment_just_confirmed,
+                    payment_just_confirmed=False,
                     conversation_id=conversation.id,
-                    product_price=product_price,
                 )
-
-                # CRM lifecycle bump: any accepted strategy slot moves a 'new'
-                # user to 'engaged'. A confirmed payment moves them to 'customer'.
-                target_stage = "customer" if payment_just_confirmed else "engaged"
                 await _bump_lifecycle_stage(
                     session,
                     client_user_id=conversation.client_user_id,
-                    target=target_stage,
+                    target="engaged",
                 )
 
     # --- 4. Auto-escalate when all purchase data is collected ----------------
-    if conversation.state != "human_handoff":
+    # Only from 'active': human_handoff has nowhere to escalate to, and 'closed'
+    # is TERMINAL. Guarding on 'active' (instead of "not human_handoff") closes
+    # a real race: confirm_payment does not bump strategy_version, so a turn
+    # already in flight when the operator closes the sale passes the staleness
+    # check, sees the operator's payment_confirmation in context (all_complete)
+    # and would resurrect a closed conversation into human_handoff — where
+    # ingest's 24h window would then trap the customer's next message
+    # (ingest.py: state != 'closed') in a conversation the bot must not answer.
+    if conversation.state == "active":
         client_row = await session.execute(
             select(Client).where(Client.id == client_id)
         )
@@ -530,9 +535,11 @@ async def _merge_profile(
 ) -> None:
     """Merge stable customer facts from extracted_context into client_users.profile.
 
-    On payment_confirmation, also increments purchase_count and appends a
-    purchase record (date, product_id, quantity, total, conversation_id) per
-    the migration-008 profile contract.
+    With ``payment_just_confirmed=True``, also increments purchase_count and
+    appends a purchase record (date, product_id, quantity, total,
+    conversation_id) per the migration-008 profile contract. Only
+    confirm_payment.py ever passes True — an agent turn always passes False
+    (ADR-009: the operator is the sole authority on a payment).
     """
     updates: dict = {}
     for ctx_key, profile_key in PROFILE_PERSIST_MAP.items():

--- a/sales_agent_api/app/services/confirm_payment.py
+++ b/sales_agent_api/app/services/confirm_payment.py
@@ -3,9 +3,12 @@
 `payment_confirmed` is the one checkpoint whose truth lives outside the whole
 system: a human looking at a payment receipt. The LLM must never propose it
 ("ya pagué" is not proof) and the backend cannot verify it (it never sees the
-image). This service is the return channel: an authorized operator — via
-whatever skin (Telegram today) — asserts "the payment is real", and the system
-records the sale, closes the conversation and updates the customer profile.
+image). That "must never" is enforced in code, not just declared here: see
+`OPERATOR_ONLY_FIELDS` in agent_action.py, which drops any payment_confirmation
+an agent turn proposes. This service is the return channel: an authorized
+operator — via whatever skin (Telegram today) — asserts "the payment is real",
+and the system records the sale, closes the conversation and updates the
+customer profile.
 
 The conversation may be in `active` (the first real sale never escalated) or
 `human_handoff`; both transition to `closed` here. `closed` ends the SALE, not
@@ -55,15 +58,22 @@ def evaluate_confirmation(state: str, extracted_context: dict) -> str:
     """Decide what an operator confirmation means for this conversation.
 
     Pure — no I/O. Returns one of:
-      - ALREADY_CONFIRMED: sale already closed by a prior confirmation —
-        idempotent no-op (safe for double-taps / Telegram retries).
+      - ALREADY_CONFIRMED: the payment is already in context — idempotent no-op
+        (safe for double-taps / Telegram retries).
       - ORDER_NOT_CONFIRMED: no user_confirmation in context — refuse.
       - CONFIRM_OK: proceed.
 
     Raises StateMachineError for states that cannot transition to closed
     (e.g. a conversation closed WITHOUT payment — not re-confirmable).
     """
-    if state == "closed" and extracted_context.get("payment_confirmation"):
+    # Idempotency is decided by the FACT (payment in context), never by the
+    # state. Tying it to `closed` is what let the duplicate sale of 2026-07-20
+    # through: the legacy LLM path recorded the sale but left the conversation
+    # in human_handoff, so this guard saw "not closed" and wrote a second sale.
+    # Since payment_confirmation is operator-only (agent_action.py:
+    # OPERATOR_ONLY_FIELDS), its presence can only mean a prior confirmation —
+    # whatever state the conversation ended up in.
+    if extracted_context.get("payment_confirmation"):
         return ALREADY_CONFIRMED
     if not extracted_context.get("user_confirmation"):
         return ORDER_NOT_CONFIRMED
@@ -84,6 +94,12 @@ async def confirm_payment(
          P2 shape) + lifecycle bump to 'customer'
       3. conversation → closed
       4. audit event `sale_closed` (actor_type='operator')
+
+    When the payment is already in context this is a pure no-op: it writes
+    NOTHING (not even the state) and reports the conversation as it stands.
+    Not closing a legacy human_handoff row is deliberate — idempotency here
+    means "never write twice", and the sale it would be closing was already
+    recorded by whoever wrote that payment_confirmation.
 
     Returns dict with: already_confirmed, new_state, side_effects.
     """

--- a/tests/services/test_agent_action.py
+++ b/tests/services/test_agent_action.py
@@ -8,8 +8,10 @@ session-touching parts of process_agent_action belong to integration tests
 Focus:
   - ORDER_FIELDS (quantity/grind/roast) persist alongside STRATEGY_FIELDS.
   - ORDER_FIELDS are NOT strategy/DAG fields → never bump lifecycle/checkpoints.
-  - DAG gates (user_confirmation, payment_confirmation) still reject when their
-    prerequisites are missing (regression guard for P2).
+  - The user_confirmation DAG gate still rejects when its prerequisites are
+    missing (regression guard for P2).
+  - payment_confirmation is OPERATOR-ONLY: an agent turn never accepts it, never
+    records a sale, never promotes to 'customer' (ADR-009 / fix venta duplicada).
   - The purchase record carries quantity + total per the migration-008 contract.
 """
 import sys
@@ -21,6 +23,7 @@ from decimal import Decimal
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../sales_agent_api"))
 
 from app.services.agent_action import (
+    OPERATOR_ONLY_FIELDS,
     ORDER_FIELDS,
     STRATEGY_FIELDS,
     compute_context_updates,
@@ -36,6 +39,14 @@ def test_order_fields_are_disjoint_from_strategy_fields():
     """The whole point: order details must NOT become DAG checkpoints."""
     assert ORDER_FIELDS.isdisjoint(STRATEGY_FIELDS)
     assert ORDER_FIELDS == {"quantity", "grind_preference", "roast_preference"}
+
+
+def test_payment_is_the_only_operator_only_field():
+    """payment_confirmation stays a DAG checkpoint (the engine reads it from
+    extracted_context) but no agent turn may write it — only the operator
+    endpoint does (ADR-009)."""
+    assert OPERATOR_ONLY_FIELDS == {"payment_confirmation"}
+    assert OPERATOR_ONLY_FIELDS <= STRATEGY_FIELDS
 
 
 # ---------------------------------------------------------------------------
@@ -122,20 +133,28 @@ def test_payment_confirmation_rejected_when_incomplete():
         {"payment_confirmation": "comprobante.jpg"}, {}
     )
     assert "payment_confirmation" not in accepted
-    assert rejections and rejections[0]["field"] == "payment_confirmation"
+    assert rejections == [
+        {"field": "payment_confirmation", "missing": ["operator_confirmation"]}
+    ]
 
 
-def test_payment_confirmation_accepted_when_prereqs_present():
+def test_payment_confirmation_rejected_even_with_every_prereq_present():
+    """THE invariant of the duplicate-sale fix: prerequisites are irrelevant.
+    The LLM has no authority over a payment, so a perfectly-formed proposal is
+    dropped exactly like an incomplete one — 'ya pagué' is not proof."""
     ctx = {
         "user_confirmation": "sí",
         "phone": "3001234567",
         "shipping_address": "Cra 1 # 2-3",
     }
-    accepted, _, rejections = compute_context_updates(
+    accepted, strategy_accepted, rejections = compute_context_updates(
         {"payment_confirmation": "comprobante.jpg"}, ctx
     )
-    assert accepted.get("payment_confirmation") == "comprobante.jpg"
-    assert rejections == []
+    assert "payment_confirmation" not in accepted
+    assert "payment_confirmation" not in strategy_accepted
+    assert rejections == [
+        {"field": "payment_confirmation", "missing": ["operator_confirmation"]}
+    ]
 
 
 def test_order_field_does_not_satisfy_a_gate():
@@ -150,13 +169,16 @@ def test_order_field_does_not_satisfy_a_gate():
 
 
 # ---------------------------------------------------------------------------
-# P3 — payment gate must not be permeable to a same-turn rejected confirmation
+# P3 (superseded) — the payment gate is gone: payment is rejected UNCONDITIONALLY,
+# so P3's scenario (payment riding on a same-turn user_confirmation) can no longer
+# exist. These keep the P3 scenarios as regression cases anyway: the guarantee
+# they encoded still holds, now for a stronger reason.
 # ---------------------------------------------------------------------------
 def test_payment_does_not_sneak_through_when_user_confirmation_rejected_same_turn():
     """The P3 bug: in ONE turn the LLM sends user_confirmation=true AND
     payment_confirmation=true, but full_name is missing. user_confirmation is
-    rejected for the missing name; payment_confirmation must NOT pass on the back
-    of a confirmation that did not survive this turn."""
+    rejected for the missing name; payment is rejected for having been proposed
+    at all."""
     ctx = {
         # full_name deliberately absent
         "phone": "3001234567",
@@ -173,15 +195,14 @@ def test_payment_does_not_sneak_through_when_user_confirmation_rejected_same_tur
         "user_confirmation",
         "payment_confirmation",
     }
-    # payment was rejected specifically because user_confirmation is now absent
     payment_rej = next(r for r in rejections if r["field"] == "payment_confirmation")
-    assert "user_confirmation" in payment_rej["missing"]
+    assert payment_rej["missing"] == ["operator_confirmation"]
 
 
-def test_payment_passes_when_user_confirmation_came_from_prior_turn():
-    """Regression: a user_confirmation already persisted in a PREVIOUS turn still
-    satisfies payment's prerequisite. Only the same-turn rejected case is blocked —
-    the legitimate payment flow must keep working."""
+def test_payment_rejected_when_user_confirmation_came_from_prior_turn():
+    """The legitimate-looking case that used to record the sale: order confirmed
+    in a PREVIOUS turn, customer now says they paid. Still rejected — the sale is
+    recorded by the operator endpoint or not at all."""
     ctx = {
         "user_confirmation": "sí",  # accepted in a prior turn
         "phone": "3001234567",
@@ -190,32 +211,36 @@ def test_payment_passes_when_user_confirmation_came_from_prior_turn():
     accepted, strategy_accepted, rejections = compute_context_updates(
         {"payment_confirmation": "comprobante.jpg"}, ctx
     )
-    assert accepted.get("payment_confirmation") == "comprobante.jpg"
-    assert strategy_accepted.get("payment_confirmation") == "comprobante.jpg"
-    assert rejections == []
+    assert "payment_confirmation" not in accepted
+    assert "payment_confirmation" not in strategy_accepted
+    assert rejections == [
+        {"field": "payment_confirmation", "missing": ["operator_confirmation"]}
+    ]
 
 
-def test_payment_passes_when_user_confirmation_valid_same_turn():
-    """When user_confirmation IS valid this turn (all prereqs present) it survives
-    the gate and stays in merged, so a same-turn payment_confirmation still passes.
-    The P3 recompute must not strip an ACCEPTED confirmation."""
+def test_valid_user_confirmation_survives_alongside_a_rejected_payment():
+    """A payment proposal must not poison the rest of the turn: a
+    user_confirmation with every prerequisite present is still accepted."""
     ctx = {
         "full_name": "Ana Ruiz",
         "phone": "3001234567",
         "shipping_address": "Cra 1 # 2-3",
         "shipping_city": "Manizales",
     }
-    accepted, _, rejections = compute_context_updates(
+    accepted, strategy_accepted, rejections = compute_context_updates(
         {"user_confirmation": "sí", "payment_confirmation": "comprobante.jpg"}, ctx
     )
     assert accepted.get("user_confirmation") == "sí"
-    assert accepted.get("payment_confirmation") == "comprobante.jpg"
-    assert rejections == []
+    assert strategy_accepted.get("user_confirmation") == "sí"
+    assert "payment_confirmation" not in accepted
+    assert rejections == [
+        {"field": "payment_confirmation", "missing": ["operator_confirmation"]}
+    ]
 
 
-def test_order_fields_persist_even_when_both_gates_reject():
-    """P2 regression under the P3 change: order details persist regardless of the
-    user/payment gates firing in the same turn."""
+def test_order_fields_persist_even_when_confirmation_and_payment_rejected():
+    """P2 regression: order details persist regardless of the user_confirmation
+    gate and the payment drop firing in the same turn."""
     accepted, strategy_accepted, rejections = compute_context_updates(
         {
             "quantity": 2,
@@ -608,3 +633,146 @@ def test_new_user_confirmation_silent_when_already_confirmed():
 def test_new_user_confirmation_silent_without_proposal():
     from app.services.agent_action import is_new_user_confirmation
     assert is_new_user_confirmation({"full_name": "Juan"}, {}) is False
+
+
+# ---------------------------------------------------------------------------
+# Fix venta duplicada — the LLM never closes a sale (on the REAL turn path)
+# ---------------------------------------------------------------------------
+import app.services.agent_action as agent_action_module
+
+# The context as the 20-jul e2e left it right before the bug: order confirmed
+# in a previous turn, everything collected, payment still pending.
+_CONFIRMED_ORDER_CTX = {
+    "product_id": "p-uuid",
+    "full_name": "Ana Ruiz",
+    "phone": "3001234567",
+    "shipping_address": "Cra 1 # 2-3",
+    "shipping_city": "Manizales",
+    "quantity": 2,
+    "user_confirmation": "sí",
+}
+
+
+def _record_profile_calls(monkeypatch) -> dict:
+    """Replace the two profile writers with recorders. Asserting on their
+    arguments is the point: they are the ONLY way a sale reaches the profile."""
+    calls: dict = {}
+
+    async def fake_merge(session, **kwargs):
+        calls["merge"] = kwargs
+
+    async def fake_bump(session, **kwargs):
+        calls["bump"] = kwargs
+
+    monkeypatch.setattr(agent_action_module, "_merge_profile", fake_merge)
+    monkeypatch.setattr(agent_action_module, "_bump_lifecycle_stage", fake_bump)
+    return calls
+
+
+def test_llm_payment_claim_records_no_sale_and_moves_nothing(monkeypatch):
+    """The duplicate-sale bug, replayed on the real path: the customer writes
+    'ya pagué' and the LLM proposes payment_confirmation with every prerequisite
+    already in context. No sale in the profile, no promotion to 'customer', no
+    payment in the context, no escalation — only a visible warning."""
+    conversation = _make_conversation(state="active")
+    conversation.extracted_context = dict(_CONFIRMED_ORDER_CTX)
+    calls = _record_profile_calls(monkeypatch)
+    session = _StubSession(
+        [
+            _StubResult(scalar=conversation),                    # load conversation
+            _StubResult(scalars_list=["B", "A"]),                # previous outbounds
+            _StubResult(),                                       # UPDATE extracted_context
+            _StubResult(scalar=SimpleNamespace(business_rules={})),  # client
+        ]
+    )
+
+    result = asyncio.run(
+        process_agent_action(
+            session=session,
+            client_id=_CLIENT_ID,
+            conversation_id=_CONV_ID,
+            strategy_version=3,
+            response_text="Recibido, muchas gracias.",
+            # the LLM re-proposes the cumulative data every turn, payment included
+            extracted_data={**_CONFIRMED_ORDER_CTX, "payment_confirmation": "ya pagué"},
+        )
+    )
+
+    # the claim is dropped but never silent
+    assert "warning:payment_claim_ignored" in result["side_effects"]
+    assert "payment_confirmation" not in conversation.extracted_context
+
+    # no sale recorded, no lifecycle promotion
+    assert calls["merge"]["payment_just_confirmed"] is False
+    assert calls["bump"]["target"] == "engaged"
+
+    # no lifecycle move for the conversation either, and the turn still flows
+    assert conversation.state == "active"
+    assert result["new_state"] == "active"
+    assert not any(s.startswith("escalated:") for s in result["side_effects"])
+    assert result["approved"] is True
+
+
+def test_payment_claim_alone_writes_nothing(monkeypatch):
+    """When the payment claim is the only thing proposed, nothing is persisted:
+    no context UPDATE, no profile write — just the warning."""
+    conversation = _make_conversation(state="active")
+    conversation.extracted_context = dict(_CONFIRMED_ORDER_CTX)
+    calls = _record_profile_calls(monkeypatch)
+    session = _StubSession(
+        [
+            _StubResult(scalar=conversation),
+            _StubResult(scalars_list=["B", "A"]),
+            _StubResult(scalar=SimpleNamespace(business_rules={})),  # client
+        ]
+    )
+
+    result = asyncio.run(
+        process_agent_action(
+            session=session,
+            client_id=_CLIENT_ID,
+            conversation_id=_CONV_ID,
+            strategy_version=3,
+            response_text="Recibido, muchas gracias.",
+            extracted_data={"payment_confirmation": True},
+        )
+    )
+
+    assert result["side_effects"] == ["warning:payment_claim_ignored"]
+    assert conversation.extracted_context == _CONFIRMED_ORDER_CTX
+    assert calls == {}
+
+
+def test_closed_conversation_is_never_resurrected_by_auto_escalate():
+    """A turn already in flight when the operator closes the sale still passes the
+    staleness check (confirm_payment does not bump strategy_version) and sees the
+    operator's payment_confirmation → all_complete. It must NOT drag the closed
+    conversation back to human_handoff, where ingest's 24h window would trap the
+    customer's next message in a conversation the bot must not answer."""
+    conversation = _make_conversation(state="closed")
+    conversation.extracted_context = {
+        **_CONFIRMED_ORDER_CTX,
+        "payment_confirmation": True,  # written by the operator endpoint
+    }
+    session = _StubSession(
+        [
+            _StubResult(scalar=conversation),
+            _StubResult(scalars_list=["B", "A"]),
+        ]
+    )
+
+    result = asyncio.run(
+        process_agent_action(
+            session=session,
+            client_id=_CLIENT_ID,
+            conversation_id=_CONV_ID,
+            strategy_version=3,
+            response_text="Recibido, muchas gracias.",
+        )
+    )
+
+    assert conversation.state == "closed"
+    assert result["new_state"] == "closed"
+    assert not any(s.startswith("escalated:") for s in result["side_effects"])
+    # the auto-escalate block was never entered: no client lookup, no UPDATE
+    assert len(session.executed) == 2

--- a/tests/services/test_confirm_payment.py
+++ b/tests/services/test_confirm_payment.py
@@ -45,6 +45,49 @@ def test_closed_and_paid_is_idempotent():
     assert evaluate_confirmation("closed", ctx) == ALREADY_CONFIRMED
 
 
+# ---------------------------------------------------------------------------
+# Fix venta duplicada — idempotency reads the FACT, not the state
+# ---------------------------------------------------------------------------
+def test_paid_in_human_handoff_is_idempotent():
+    """The exact hole that produced the duplicate sale of 2026-07-20: the legacy
+    LLM path recorded the sale but left the conversation in human_handoff, so a
+    guard tied to `closed` concluded "not confirmed yet" and wrote a SECOND sale.
+    A payment already in context ends it, whatever the state."""
+    ctx = {**CONFIRMED_ORDER_CTX, "payment_confirmation": True}
+    assert evaluate_confirmation("human_handoff", ctx) == ALREADY_CONFIRMED
+
+
+def test_paid_in_active_is_idempotent():
+    ctx = {**CONFIRMED_ORDER_CTX, "payment_confirmation": True}
+    assert evaluate_confirmation("active", ctx) == ALREADY_CONFIRMED
+
+
+def test_bug_sequence_yields_exactly_one_sale():
+    """The 20-jul sequence end to end, in pure logic: the LLM proposes the
+    payment (22:45) and the operator presses the button (22:46).
+
+    Post-fix the LLM proposal never reaches the context, so the operator's
+    confirmation is the FIRST and only one that records a sale — and a second
+    press after it is an idempotent no-op. One sale, not two."""
+    from app.services.agent_action import compute_context_updates
+
+    accepted, _, rejections = compute_context_updates(
+        {"payment_confirmation": "ya pagué"}, CONFIRMED_ORDER_CTX
+    )
+    assert "payment_confirmation" not in accepted
+    assert rejections == [
+        {"field": "payment_confirmation", "missing": ["operator_confirmation"]}
+    ]
+
+    # the context the operator's button then finds — still unpaid
+    ctx_after_llm = {**CONFIRMED_ORDER_CTX, **accepted}
+    assert evaluate_confirmation("human_handoff", ctx_after_llm) == CONFIRM_OK
+
+    # ...and the sale it records is the only one: a re-press writes nothing
+    ctx_after_operator = {**ctx_after_llm, "payment_confirmation": True}
+    assert evaluate_confirmation("closed", ctx_after_operator) == ALREADY_CONFIRMED
+
+
 def test_active_without_user_confirmation_refused():
     """Strict precondition: nothing to close if the customer never confirmed."""
     ctx = {k: v for k, v in CONFIRMED_ORDER_CTX.items() if k != "user_confirmation"}


### PR DESCRIPTION
## Qué arregla

El e2e del lazo de handoff (2026-07-20, conversación `9635…bce7`) registró la venta **dos veces** en el profile del cliente: `purchase_count: 2`, dos registros idénticos (mismo product_id, quantity 2, total 80000, misma conversación) separados 67 segundos.

**Causa raíz**: ADR-009 construyó el camino nuevo (operador revisa el comprobante → botón → `POST /operator/confirm-payment`) pero nunca **retiró** el viejo (el cliente escribe "ya pagué" → el LLM propone `payment_confirmation` → el gate solo valida precondiciones, no el origen → el backend registra la venta). Dos autoridades vivas sobre el mismo hecho, ambas escribiendo. Es exactamente la **alternativa B que ADR-009 rechazó** ("'ya pagué' no es prueba de pago"), viva en el código y en el prompt.

La idempotencia del endpoint tampoco lo atrapó: su guard era `state == "closed" AND payment_confirmation`, y el camino viejo dejaba la conversación en `human_handoff`. Miraba el estado, no el hecho.

## Los cambios (Fase 1 del brief `docs/briefs/impl-brief-fix-venta-duplicada.md`)

**A — `agent_action.py`**: nueva constante `OPERATOR_ONLY_FIELDS`. Un `payment_confirmation` propuesto por el LLM se descarta **siempre** — sin gate, sin precondiciones que discutir — con side effect visible `warning:payment_claim_ignored`. Un turno del agente ya no registra venta ni promueve a `customer`. Esto **supera y elimina** el gate P3 (PR #48): su escenario (el pago colándose sobre un `user_confirmation` del mismo turno) es ahora imposible por una razón más fuerte.

**C — `confirm_payment.py`**: la idempotencia decide por el **hecho** (pago en contexto), no por el estado.

**B1 — `migrations/versions/011_*.sql`**: saca del `system_prompt_template` la instrucción de emitir `payment_confirmation`. Edición quirúrgica (`REPLACE`, idempotente), no re-escribe el template. **No cambia el comportamiento de cobro**: `FLUJO DE COMPRA`, `COMPROBANTE DE PAGO` y `HANDOFF HUMANO` quedan intactos — el bot sigue pidiendo el comprobante.

**Hallazgo del mismo radio**: el auto-escalate corría con cualquier estado `!= human_handoff`. Como `confirm_payment` no sube `strategy_version`, un turno en vuelo pasaba el chequeo de staleness, veía el pago del operador (`all_complete`) y **resucitaba la conversación cerrada** a `human_handoff` — donde la ventana de 24h del ingest atrapaba el siguiente mensaje del cliente en una conversación que el bot no debe contestar. Ahora solo escala desde `active`.

## El invariante que queda escrito en código

> `payment_confirmation` presente en `extracted_context` significa exactamente una cosa: **un operador lo confirmó**.

## Consecuencia de diseño aceptada

El turno del agente ya no escala por venta completa. Tras la confirmación del pedido la conversación sigue en `active` (el bot acompaña) hasta que el operador pulsa el botón y cierra. El único escalamiento automático que queda es el circuit breaker. Se descartó escalar con el claim del LLM: un "ya pagué" falso o alucinado dejaría la conversación congelada sin vía de retorno (no existe endpoint `human_handoff → active`).

## Tests

**162 verdes** (155 previos + 7 nuevos). Los 4 tests que codificaban la semántica vieja se reescribieron — la garantía de P3 sobrevive, ahora por una razón más fuerte.

Nuevos: invariante operator-only; el turno real vía `process_agent_action` (asertando que `_merge_profile`/`_bump_lifecycle_stage` nunca reciben `payment_just_confirmed=True` ni `"customer"`); "el claim solo no escribe nada"; el guard de `closed`; idempotencia en `human_handoff` y `active`; y la secuencia del bug de punta a punta → una sola venta.

**Verificados por mutación**, no solo "pasan": con `OPERATOR_ONLY_FIELDS = set()` caen 10; con el guard viejo cae el de resurrección mostrando `closed → human_handoff`.

## Pendiente fuera de este PR

- [ ] Aplicar la migración `011` en prod (manual, convención `-- Applied:`)
- [ ] **Fase 2 (n8n vivo)**: quitar `payment_confirmation` de las "Valid extracted_data keys" del nodo "Build LLM Prompt" de `cafe_arenillo_v2` — sesión aparte, export antes/después
- [ ] Limpiar la fila sucia del e2e (`client_user 15d89710…`, `purchase_count: 2` → 1, conservando el registro del operador de las 22:46:45)

Detalle menor para la Fase 2: `operator_confirm_telegram` responde "ya estaba confirmada y cerrada" ante `already_confirmed`, y en el caso legado (pago en contexto con la conversación aún en `human_handoff`) el endpoint no cierra — el mensaje mentiría a medias. Solo aplica a filas anteriores a este fix; anotado en las notas as-built de ADR-009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)