### PR TITLE
chore(migrations): marcar 011 como aplicada en prod (2026-07-31)

### DIFF
--- a/migrations/versions/011_remove_payment_confirmation_from_prompt.sql
+++ b/migrations/versions/011_remove_payment_confirmation_from_prompt.sql
@@ -26,7 +26,8 @@
 --
 -- No schema change.
 --
--- Applied:
+-- Applied: 2026-07-31 (prod, manualmente vía psql, transacción única con
+--          verificación: 17340 → 17261 caracteres, 0 menciones restantes)
 
 UPDATE clients
    SET system_prompt_template = REPLACE(


### PR DESCRIPTION
Seguimiento de #57: ese PR se mergeó (20:22 UTC) unos minutos antes de que la migración se aplicara en prod (20:27 UTC), así que el marcador `-- Applied:` quedó fuera de `main`. Este PR solo lo incorpora — sin este cambio, el repo dice que la 011 está pendiente cuando ya corrió.

**Cómo se aplicó** (manual vía `psql`, convención del repo):
- Pre-check: el template tenía 17340 caracteres, exactamente el de la migración 009 → sin drift en el prompt de producción.
- Transacción única con `ON_ERROR_STOP` y un bloque de verificación que aborta si el resultado no es el predicho (0 menciones de `payment_confirmation` y 17261 caracteres). Salió `UPDATE 1` + verificación OK.
- Verificación independiente posterior: `tpl_len = 17261`, sin menciones, `updated_at = 2026-07-31 20:27:24 UTC`. Las secciones `FLUJO DE COMPRA`, `COMPROBANTE DE PAGO` y `HANDOFF HUMANO` intactas — el bot sigue pidiendo el comprobante.

Solo toca un comentario del `.sql`. Sin cambios de código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)