### PR TITLE
P14 · Identidad por BSUID: schema + backend (Fases 1 y 2)

### DIFF
--- a/migrations/versions/012_add_bsuid_identity.sql
+++ b/migrations/versions/012_add_bsuid_identity.sql
@@ -1,0 +1,80 @@
+-- Migration 012: identidad por BSUID (privacidad de número de WhatsApp)
+--
+-- Contexto (P14 — mensaje perdido del 2026-08-04, ejecución n8n 9459):
+-- WhatsApp desplegó privacidad de número. Cuando un cliente la activa, Meta deja
+-- de mandar `from` y `wa_id` en el webhook y lo identifica SOLO con su BSUID
+-- (Business-Scoped User ID, formato `CO.1034312865991667`). Una clienta real
+-- escribió "Hola" y el sistema la descartó en silencio: el teléfono era la única
+-- identidad que sabía leer, y no venía. Diagnóstico completo: el payload es
+-- pass-through verbatim de Meta y `from_user_id`/`user_id` YA llegan en todos los
+-- mensajes — el problema era de parsing y de schema, no de transporte.
+--
+-- Esta migración abre el schema para que la identidad NO sea el teléfono:
+--
+--   1. client_users.bsuid — la identidad de WhatsApp, en columna propia. No se
+--      mete el BSUID en phone_number: son cosas distintas (uno es identidad, el
+--      otro un dato de contacto opcional) y meterlos en la misma columna miente
+--      sobre lo que guarda. Además phone_number es VARCHAR(20), corto para
+--      BSUIDs largos.
+--
+--   2. Unicidad (client_id, bsuid). Confirmado por Chakra Support: Meta emite un
+--      BSUID DISTINTO por cada WABA, así que el mismo cliente físico tiene un
+--      BSUID por tenant. El BSUID significa "esta persona ante ESTE negocio",
+--      nunca "esta persona". Por eso la unicidad es por tenant y jamás global —
+--      Meta lo diseñó así por privacidad, no es una limitación a sortear.
+--
+--   3. phone_number pasa a NULLABLE. Un cliente con privacidad activada es un
+--      cliente perfectamente válido del que no conocemos el teléfono.
+--
+-- Qué NO toca, a propósito: el constraint uq_client_user_phone (client_id,
+-- phone_number) queda VIVO. Dos razones:
+--   (a) El código en producción lo referencia POR NOMBRE en su upsert
+--       (services/ingest.py — on_conflict_do_update(constraint="uq_client_user_phone")),
+--       así que dropearlo haría fallar cada ingest hasta desplegar la Fase 2.
+--       Dejarlo hace que esta migración sea retrocompatible: se puede aplicar con
+--       el código actual desplegado, sin ventana de rotura y sin acoplar el orden
+--       migración↔deploy.
+--   (b) Sigue siendo útil. Con phone_number nullable los NULL no colisionan entre
+--       sí en un UNIQUE, así que el constraint conserva su invariante (un registro
+--       por tenant y teléfono) exactamente entre las filas que SÍ tienen teléfono.
+-- Lo único que podría querer retirarlo es la fusión phone↔BSUID, que está fuera
+-- de alcance a propósito y va en su propio ADR (identidad primaria por BSUID).
+--
+-- Applied:
+
+-- ---------------------------------------------------------------------------
+-- 1. Columna bsuid
+-- ---------------------------------------------------------------------------
+ALTER TABLE client_users
+  ADD COLUMN IF NOT EXISTS bsuid VARCHAR(140);
+
+COMMENT ON COLUMN client_users.bsuid IS
+  'Business-Scoped User ID de WhatsApp: country code + "." + identificador '
+  '(ej. CO.1034312865991667). Identidad del cliente ante ESTE tenant — Meta emite '
+  'un BSUID distinto por WABA, por eso la unicidad es (client_id, bsuid) y nunca '
+  'global. NULL en las filas anteriores a P14 y en clientes vistos solo por '
+  'teléfono. VARCHAR(140) da margen sobre el máximo de Meta (128 + prefijo); los '
+  'observados en producción miden 19.';
+
+-- ---------------------------------------------------------------------------
+-- 2. Unicidad del BSUID por tenant
+-- ---------------------------------------------------------------------------
+-- Índice único COMPLETO (sin WHERE) a propósito. Postgres trata cada NULL como
+-- distinto, así que las filas sin BSUID no colisionan y no hace falta un índice
+-- parcial. Se evita el parcial deliberadamente: obligaría al ON CONFLICT de la
+-- Fase 2 a repetir el predicado (index_where) para que Postgres pueda inferir el
+-- índice. Con el índice completo el upsert infiere con (client_id, bsuid) a secas.
+--
+-- Sirve además como el índice de lectura de la resolución de identidad
+-- (SELECT ... WHERE client_id = :c AND bsuid = :b), así que no se agrega otro.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_client_users_client_bsuid
+  ON client_users (client_id, bsuid);
+
+-- ---------------------------------------------------------------------------
+-- 3. phone_number deja de ser obligatorio
+-- ---------------------------------------------------------------------------
+-- La identidad ya no es el teléfono. Nótese que el modelo ORM sigue declarando
+-- nullable=False hasta la Fase 2; es inofensivo — SQLAlchemy usa `nullable` para
+-- generar DDL, no para validar en runtime.
+ALTER TABLE client_users
+  ALTER COLUMN phone_number DROP NOT NULL;

--- a/migrations/versions/012_add_bsuid_identity.sql
+++ b/migrations/versions/012_add_bsuid_identity.sql
@@ -40,7 +40,13 @@
 -- Lo único que podría querer retirarlo es la fusión phone↔BSUID, que está fuera
 -- de alcance a propósito y va en su propio ADR (identidad primaria por BSUID).
 --
--- Applied:
+-- Applied: 2026-08-17 (prod, manualmente vía psql, transacción única con
+--          verificación: bsuid VARCHAR(140) nullable creado, phone_number pasó
+--          a nullable, índice uq_client_users_client_bsuid creado sobre
+--          (client_id, bsuid), y uq_client_user_phone INTACTO — confirmando que
+--          el upsert del código entonces desplegado seguía resolviendo por
+--          nombre de constraint. 0 de 33 filas con bsuid, como se esperaba:
+--          todos los client_users existentes son pre-P14.)
 
 -- ---------------------------------------------------------------------------
 -- 1. Columna bsuid

--- a/sales-ai-docs/docs/briefs/impl-brief-P14-lid-bsuid-final.md
+++ b/sales-ai-docs/docs/briefs/impl-brief-P14-lid-bsuid-final.md
@@ -1,0 +1,177 @@
+# Brief de implementación — P14: mensajes LID/privacidad (BSUID) — recibir + responder
+
+> **Definitivo.** Reemplaza el brief anterior (que quedó en stand-by esperando a Chakra).
+> Chakra CONFIRMÓ soporte del campo `recipient` para responder a BSUIDs, así que este
+> brief cubre recibir Y responder en un solo trabajo. SIN telemetría-de-derrota (no se
+> construye el parche de "no pude atender"): el sistema recibe y responde, flujo completo.
+>
+> **Sistema REAL**: FastAPI en prod, Postgres 6 tablas post-007, n8n vivo (`master`
+> , `cafe_arenillo_v2`), Chakra HQ transporte.
+> Edita código, schema (migración), n8n vivo.
+>
+> **Alcance**: que los mensajes de clientes con privacidad ENTREN, se identifiquen por
+> BSUID, se persistan, y se pueda RESPONDERLES vía BSUID. Identidad técnica por BSUID.
+> **FUERA**: el rediseño de identidad primaria de negocio (BSUID como clave de negocio +
+> teléfono recolectado en el DAG como dato de envío + manejo de user_id_update) → su
+> propio ADR posterior (ver "Lo que sigue" al final).
+>
+> **Disciplina**: fases por riesgo. Plan por archivo antes de codear, espera confirmación.
+> Cada fase su commit + test. Ramas desde origin/main (fetch primero). Export n8n
+> antes/después. NO desplegar sin OK.
+
+---
+
+## Contexto y hallazgos confirmados
+
+**Problema**: WhatsApp desplegó privacidad de número (BSUID). Para clientes con privacidad
+activada, Meta omite `from`/`wa_id` y manda solo el BSUID (`CO.1034…`). El sistema perdía
+estos mensajes en silencio. **Evidencia**: clienta real "Juan Perez"
+(`CO.1034312865991667`) perdida el 2026-08-01, drop silencioso (Stop "success" 15ms).
+
+**Confirmado contra el payload REAL (diagnóstico exec 9459 vs 9461)**:
+1. Los campos BSUID YA llegan — formato pass-through verbatim de Meta. `user_id` y
+   `from_user_id` presentes en TODOS los mensajes. NO hay que cambiar webhook ni pedir
+   nada a Chakra para recibir. El problema es de parsing propio.
+2. La única diferencia entre payload normal y de LID: faltan `wa_id` y `from`.
+3. **Causa PRIMARIA**: `master` / `map_webhook_data_arenillo` (nodo `Set` whitelist)
+   copia solo 6 campos y DESTRUYE `from_user_id`, `user_id`, `username`, `wa_id` antes de
+   procesar. Arreglar solo el `If` NO funcionaría.
+4. **Causa secundaria**: `cafe_arenillo_v2` / `If Message Exists` valida `from` strict → Stop.
+
+**Confirmado por Chakra Support**:
+- Soportan el campo `recipient` en sus APIs pass-through de envío → **se puede responder a
+  un BSUID sin teléfono.**
+- **Los BSUID están scoped a un solo WABA ID.** El mismo cliente físico tiene un BSUID
+  DISTINTO por cada WABA/tenant. → requisito multi-tenant duro (abajo).
+
+## Rutas de campos (verificadas contra payload real)
+
+Bajo `body.entry[0].changes[0].value`:
+- **Identidad (BSUID)** — 100% presente: `messages[0].from_user_id` (= `contacts[0].user_id`)
+- **Teléfono** — OPCIONAL, puede faltar, NUNCA clave: `messages[0].from` (= `contacts[0].wa_id`)
+- **Username** — display: `contacts[0].profile.username`
+- **Nombre** — NO garantizado.
+
+## Dos sutilezas OBLIGATORIAS
+
+1. **El guard discrimina PRIMERO mensaje-vs-status.** Los status callbacks
+   (`value.statuses[]`, sin `value.messages[]`) DEBEN seguir cayendo a Stop. Exigir
+   `value.messages[0].id` antes de extraer identidad. NO solo cambiar `from`→`from_user_id`.
+2. **NO usar `name`/`username` como condición** de validez — no garantizados. Sí como display.
+
+## Requisito multi-tenant DURO (confirmado por Chakra)
+
+El BSUID es scoped por WABA. El mismo cliente tiene BSUID distinto por tenant. Por tanto:
+- La unicidad del `bsuid` es **por tenant: `(client_id, bsuid)`**, NUNCA global.
+- El BSUID identifica "esta persona ante ESTE negocio", no "esta persona". No usarlo como
+  identidad cross-tenant. (Meta lo diseñó así por privacidad — es correcto, no una
+  limitación a sortear.)
+
+---
+
+## FASE 1 — Schema (migración) [DB]
+
+**Decisión**: campo `bsuid` propio + `phone_number` opcional (NO meter BSUID en
+`phone_number` — miente sobre lo que guarda; además es `VARCHAR(20)`, corto para BSUIDs).
+
+> **Nomenclatura**: la columna real es **`client_users.phone_number`** (`core.py:74`). Ojo
+> con `phone`: es OTRA cosa — el slot del DAG en `lead_qualified`, que vive en
+> `extracted_context`, no una columna. En este brief `phone_number` = columna,
+> `phone` = slot del DAG.
+
+- Migración nueva (secuencial, `-- Applied:` en blanco, NO aplicar en sesión):
+  - `bsuid VARCHAR(140)` en `client_users` (country code + `.` + hasta 128 chars; 140 da
+    margen).
+  - `phone_number` NULLABLE (quitar NOT NULL). La identidad ya no es el teléfono.
+  - Índice único **compuesto `(client_id, bsuid)`** — scoping por tenant (requisito duro).
+- **NO dropear `uq_client_user_phone`** (el `UNIQUE (client_id, phone_number)` de 001).
+  Corrección sobre la versión previa de este brief, que pedía quitarlo: el código vivo lo
+  referencia por nombre (`ingest.py:121` — `on_conflict_do_update(constraint=...)`), así que
+  dropearlo rompe cada ingest hasta desplegar la Fase 2. Y sigue siendo útil: con
+  `phone_number` nullable los NULL no colisionan entre sí, así que conserva su invariante
+  solo entre las filas que sí tienen teléfono. Dejarlo hace la migración retrocompatible.
+  Retirarlo, si algún día hace falta, es cosa de la fusión phone↔BSUID → ADR posterior.
+- NO tocar lógica de identidad compleja (user_id_update, fusión) — es el ADR posterior.
+
+## FASE 2 — Backend: identidad técnica por BSUID [B]
+
+- Ingest/upsert de `client_user` usa `bsuid` como clave dentro del tenant (`client_id`).
+  BSUID-first. Si hay teléfono, se guarda como atributo; si no, null.
+- Resolución: buscar por `(client_id, bsuid)`. Si no existe, crear con el BSUID.
+  (Fusión phone↔BSUID y write-back = ADR posterior; aquí solo BSUID como clave.)
+- El upsert deja de inferir por `uq_client_user_phone` y pasa a `(client_id, bsuid)`
+  (índice `uq_client_users_client_bsuid` de la migración 012, completo y no parcial
+  justamente para que el `ON CONFLICT` infiera sin repetir predicado).
+- Pydantic: `from`, `wa_id`, `phone_number` OPCIONALES. Su ausencia no rompe validación.
+- Dedupe por `chakra_message_id` (wamid), no por teléfono (verificar que ya es así).
+- Tests (puros): payload con BSUID sin teléfono → identifica/crea por bsuid; con ambos →
+  guarda los dos; ausencia de `from`/`wa_id` no rompe.
+
+## FASE 3 — n8n: recibir [N8N] (export antes/después)
+
+- **`master` / `map_webhook_data_arenillo`** (el `Set`): añadir a los campos copiados
+  `from_user_id`, `user_id`, `username`, `wa_id`. **Fix PRIMARIO** — sin esto la identidad
+  se sigue destruyendo aquí.
+- **`cafe_arenillo_v2` / `If Message Exists`**: guard discrimina mensaje-vs-status
+  (exigir `value.messages[0].id`) y usa `from_user_id` como identidad, no `from`. Status
+  callbacks siguen a Stop.
+- **`Normalize Inbound`**: usar `from_user_id` como identidad; `from` como teléfono
+  opcional (`phone = message.from || null`, no `|| ''`).
+
+## FASE 4 — n8n: responder vía BSUID [N8N] (Chakra confirmó)
+
+- El nodo de envío hoy usa `"to": phone_number`. Cambiar a: **si hay teléfono, `to`; si
+  NO, `recipient: <bsuid>`** (omitir `to`). Chakra pasa `recipient` en su API pass-through.
+- Usar el BSUID completo verbatim (country code + `.` + todo).
+- Respetar la ventana de 24h (el inbound del cliente la abre, sea por teléfono o BSUID) —
+  responder texto libre dentro de ella; ya es el caso de uso normal.
+- (Plantillas de autenticación NO soportan BSUID y requieren teléfono — no aplica hoy,
+  solo texto libre en ventana. Anotar por si acaso.)
+
+---
+
+## Secuencia y verificación
+
+**Orden**: FASE 1 (schema) → FASE 2 (backend) → FASE 3 (n8n recibir) → FASE 4 (n8n
+responder). Recibir antes que responder (no puedes responder a quien no identificaste).
+
+**Verificación e2e**: mandar un mensaje real desde un WhatsApp con privacidad de número
+activada (o simular payload sin `from`/`wa_id`). Confirmar el flujo COMPLETO: el mensaje
+ENTRA → se identifica/crea client_user por `(client_id, bsuid)` → se persiste → **el bot
+RESPONDE** (vía `recipient`) → la conversación fluye normal. Revisar la DB, no solo la
+conversación (los bugs se esconden en el estado).
+
+**Definition of done**:
+- Un mensaje solo-BSUID (sin `from`/`wa_id`) ENTRA, se identifica por bsuid, y el bot le
+  RESPONDE. Cero drop silencioso, cero parche de derrota.
+- Status callbacks siguen cayendo a Stop.
+- `phone_number` nullable; `bsuid` en columna propia con índice único `(client_id, bsuid)`.
+- Ausencia de teléfono no rompe validación, ingest, ni respuesta.
+- Respuesta vía `recipient` funciona dentro de la ventana de 24h.
+
+**No tocar**: rediseño de identidad de negocio (ADR posterior), north-star, nada fuera
+del alcance.
+
+---
+
+## Lo que sigue (NO en este brief) — ADR de identidad primaria por BSUID
+
+Tu pregunta —enfocar la identidad en el BSUID en vez del teléfono, y que el bot recolecte
+el teléfono durante el DAG como dato de envío— es el rediseño de fondo, y merece su ADR:
+
+- **BSUID como identidad PRIMARIA de negocio** (no solo técnica): el cliente ES su BSUID
+  (por tenant); el teléfono pasa a ser un atributo de logística.
+- **El teléfono se recolecta en el DAG como dato de ENVÍO, no de identidad**: encaja en
+  `shipping_info_collected` ("para coordinar la entrega, ¿un número de contacto?"). Ventaja:
+  el bot pide el teléfono solo cuando lo necesita (al coordinar envío), no como requisito
+  de identidad al inicio — respeta la privacidad que el cliente eligió, y solo pide el dato
+  cuando hay razón de negocio (el mensajero necesita llamarlo).
+- **Manejar `user_id_update`**: cuando el cliente cambia de teléfono, el BSUID cambia;
+  Meta manda previous→current para re-vincular.
+- **Migración de clientes viejos** que solo tienen teléfono, sin BSUID: cómo se concilian
+  cuando vuelven a escribir (write-back del BSUID sobre el registro existente).
+- **Contact Book / `REQUEST_CONTACT_INFO`** si se necesita recuperar teléfono activamente.
+
+Es importante pero NO urgente (el sistema funciona con BSUID como clave técnica sin el
+rediseño) y grande (toca modelo de datos, DAG, migración de clientes viejos). Primero para
+la hemorragia (este brief); luego el rediseño con calma (ese ADR).

--- a/sales_agent_api/app/api/v1/ingest.py
+++ b/sales_agent_api/app/api/v1/ingest.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.database import get_session
@@ -24,12 +24,27 @@ router = APIRouter()
 # Request / Response schemas
 # ---------------------------------------------------------------------------
 class IngestMessageRequest(BaseModel):
+    """Inbound message from n8n.
+
+    Both identity fields are optional *individually* but at least one must be
+    present. A customer with WhatsApp number-privacy enabled arrives with only
+    a `bsuid` and no phone at all; conversely n8n sends only `phone_number`
+    until the workflow is updated (P14 Fase 3), so both shapes must be accepted.
+    """
+
     chakra_message_id: str
-    phone_number: str
+    bsuid: Optional[str] = None
+    phone_number: Optional[str] = None
     content: str
     display_name: Optional[str] = None
     message_type: str = "text"
     timestamp: Optional[datetime] = None
+
+    @model_validator(mode="after")
+    def _require_some_identity(self) -> "IngestMessageRequest":
+        if not self.bsuid and not self.phone_number:
+            raise ValueError("at least one of 'bsuid' or 'phone_number' is required")
+        return self
 
 
 class IngestMessageResponse(BaseModel):
@@ -69,6 +84,7 @@ async def ingest_message_endpoint(
             session=session,
             client_id=client_id,
             chakra_message_id=body.chakra_message_id,
+            bsuid=body.bsuid,
             phone_number=body.phone_number,
             content=body.content,
             display_name=body.display_name,

--- a/sales_agent_api/app/models/core.py
+++ b/sales_agent_api/app/models/core.py
@@ -71,7 +71,14 @@ class ClientUser(Base):
     client_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("clients.id"), nullable=False
     )
-    phone_number: Mapped[str] = mapped_column(String(20), nullable=False)
+    # Identity. The BSUID (Business-Scoped User ID, e.g. "CO.1034312865991667")
+    # is the primary identity: WhatsApp's number-privacy rollout means a customer
+    # may reach us with NO phone number at all. It is scoped per WABA, so it is
+    # unique per tenant — never globally (index uq_client_users_client_bsuid,
+    # migration 012). phone_number is an optional contact attribute; it is NULL
+    # for privacy-enabled customers and populated for everyone seen before P14.
+    bsuid: Mapped[Optional[str]] = mapped_column(String(140))
+    phone_number: Mapped[Optional[str]] = mapped_column(String(20))
     display_name: Mapped[Optional[str]] = mapped_column(String(255))
     # Persistent customer profile across conversations. Shape documented in
     # migration 007: {first_name, full_name, email, city, shipping_address,

--- a/sales_agent_api/app/services/ingest.py
+++ b/sales_agent_api/app/services/ingest.py
@@ -77,8 +77,9 @@ async def ingest_message(
     session: AsyncSession,
     client_id: uuid.UUID,
     chakra_message_id: str,
-    phone_number: str,
     content: str,
+    bsuid: Optional[str] = None,
+    phone_number: Optional[str] = None,
     display_name: Optional[str] = None,
     message_type: str = "text",
     timestamp: Optional[datetime] = None,
@@ -106,32 +107,22 @@ async def ingest_message(
         logger.info("Duplicate message rejected: chakra_message_id=%s", chakra_message_id)
         raise DuplicateMessageError(f"Message {chakra_message_id} already processed")
 
-    # --- 3. Upsert client_user -----------------------------------------------
+    # --- 3. Resolve client_user (BSUID-first) --------------------------------
     now = datetime.now(timezone.utc)
-    upsert_stmt = (
-        pg_insert(ClientUser)
-        .values(
-            client_id=client_id,
-            phone_number=phone_number,
-            display_name=display_name,
-            first_contact_at=now,
-            last_contact_at=now,
-        )
-        .on_conflict_do_update(
-            constraint="uq_client_user_phone",
-            set_={
-                "display_name": display_name,
-                "last_contact_at": now,
-            },
-        )
-        .returning(ClientUser)
+    client_user = await _resolve_client_user(
+        session=session,
+        client_id=client_id,
+        bsuid=bsuid,
+        phone_number=phone_number,
+        display_name=display_name,
+        now=now,
     )
-    result = await session.execute(upsert_stmt)
-    client_user: ClientUser = result.scalar_one()
 
     # --- 4. Block check -------------------------------------------------------
     if client_user.is_blocked:
-        raise UserBlockedError(f"User {phone_number} is blocked")
+        raise UserBlockedError(
+            f"User {_mask_identity(bsuid, phone_number)} is blocked"
+        )
 
     # --- 5. Find or create conversation (24h window) -------------------------
     window_start = now - timedelta(hours=24)
@@ -288,7 +279,7 @@ async def ingest_message(
             actor_type="system",
             new_value={
                 "chakra_message_id": chakra_message_id,
-                "phone_number": _mask_phone(phone_number),
+                "identity": _mask_identity(bsuid, phone_number),
                 "conversation_id": str(conversation.id),
             },
         )
@@ -372,6 +363,7 @@ async def ingest_message(
         "user_context": {
             "display_name": client_user.display_name,
             "phone_number": _mask_phone(phone_number),
+            "bsuid": _mask_phone(bsuid) if bsuid else None,
             "profile": client_user.profile or {},
             "is_blocked": client_user.is_blocked,
         },
@@ -432,8 +424,114 @@ async def _find_last_conversation(
     return row.scalar_one_or_none()
 
 
-def _mask_phone(phone: str) -> str:
+async def _resolve_client_user(
+    session: AsyncSession,
+    client_id: uuid.UUID,
+    bsuid: Optional[str],
+    phone_number: Optional[str],
+    display_name: Optional[str],
+    now: datetime,
+) -> ClientUser:
+    """Find or create the client_user for an inbound message, BSUID-first.
+
+    WhatsApp's number-privacy rollout means the phone number is no longer a
+    reliable identity: a customer may arrive with only a BSUID. Resolution
+    order:
+
+      1. By (client_id, bsuid) — the real identity when we have it.
+      2. By (client_id, phone_number) — a customer we met BEFORE P14 is stored
+         phone-keyed with bsuid NULL. Reusing that row is what keeps them from
+         being duplicated and losing their profile/history. We deliberately do
+         NOT write the bsuid back onto that row: proving "these two identities
+         are the same person" and merging them is the identity redesign, which
+         has its own ADR. Here we only avoid making the problem worse.
+      3. Insert. Uses ON CONFLICT so that a concurrent ingest for the same new
+         customer converges instead of raising — the advisory lock is only
+         taken later (step 6), so this step is genuinely racy.
+
+    When no bsuid is supplied at all (n8n before P14 Fase 3) this falls through
+    to the original phone-keyed upsert, unchanged.
+    """
+    set_on_match = {"display_name": display_name, "last_contact_at": now}
+
+    if bsuid:
+        found = await session.execute(
+            select(ClientUser).where(
+                ClientUser.client_id == client_id, ClientUser.bsuid == bsuid
+            )
+        )
+        existing: Optional[ClientUser] = found.scalar_one_or_none()
+
+        if existing is None and phone_number:
+            found = await session.execute(
+                select(ClientUser).where(
+                    ClientUser.client_id == client_id,
+                    ClientUser.phone_number == phone_number,
+                )
+            )
+            existing = found.scalar_one_or_none()
+
+        if existing is not None:
+            if display_name:
+                existing.display_name = display_name
+            existing.last_contact_at = now
+            return existing
+
+        # New customer. Safe against uq_client_user_phone: we only get here when
+        # the phone lookup above found nothing (or there is no phone at all, and
+        # NULLs do not collide in a unique index).
+        insert_stmt = (
+            pg_insert(ClientUser)
+            .values(
+                client_id=client_id,
+                bsuid=bsuid,
+                phone_number=phone_number,
+                display_name=display_name,
+                first_contact_at=now,
+                last_contact_at=now,
+            )
+            .on_conflict_do_update(
+                index_elements=["client_id", "bsuid"],
+                set_=set_on_match,
+            )
+            .returning(ClientUser)
+        )
+        return (await session.execute(insert_stmt)).scalar_one()
+
+    # No BSUID: the pre-P14 path, byte-for-byte as it was.
+    upsert_stmt = (
+        pg_insert(ClientUser)
+        .values(
+            client_id=client_id,
+            phone_number=phone_number,
+            display_name=display_name,
+            first_contact_at=now,
+            last_contact_at=now,
+        )
+        .on_conflict_do_update(
+            constraint="uq_client_user_phone",
+            set_=set_on_match,
+        )
+        .returning(ClientUser)
+    )
+    return (await session.execute(upsert_stmt)).scalar_one()
+
+
+def _mask_phone(phone: Optional[str]) -> str:
     """Mask PII: keep only last 4 digits."""
+    if not phone:
+        return "****"
     if len(phone) <= 4:
         return "****"
     return "*" * (len(phone) - 4) + phone[-4:]
+
+
+def _mask_identity(bsuid: Optional[str], phone_number: Optional[str]) -> str:
+    """Mask whichever identity we have, preferring the BSUID.
+
+    Never returns a bare None: a privacy-enabled customer has no phone at all,
+    and log lines saying "User None" help nobody.
+    """
+    if bsuid:
+        return _mask_phone(bsuid)
+    return _mask_phone(phone_number)

--- a/tests/services/test_ingest_identity.py
+++ b/tests/services/test_ingest_identity.py
@@ -1,0 +1,209 @@
+"""P14 — identity resolution for inbound messages (BSUID-first).
+
+WhatsApp's number-privacy rollout means the phone number is no longer a
+reliable identity. These tests pin the resolution ORDER and, just as
+importantly, what the fallback deliberately does NOT do (write the bsuid back
+onto a legacy row — that merge is the identity redesign's job, not this one).
+
+Pure tests: the session is a stub that records what was asked and replays
+canned answers, per the repo convention that tests/services needs no DB.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../sales_agent_api"))
+
+from app.api.v1.ingest import IngestMessageRequest
+from app.models.core import ClientUser
+from app.services.ingest import _mask_identity, _mask_phone, _resolve_client_user
+
+CLIENT_ID = uuid.UUID("00000000-0000-0000-0000-000000000001")
+NOW = datetime(2026, 8, 4, 19, 51, 14, tzinfo=timezone.utc)
+BSUID = "CO.1034312865991667"
+PHONE = "573107148477"
+
+
+# ---------------------------------------------------------------------------
+# Session stub
+# ---------------------------------------------------------------------------
+class _Result:
+    def __init__(self, row):
+        self._row = row
+
+    def scalar_one_or_none(self):
+        return self._row
+
+    def scalar_one(self):
+        return self._row
+
+
+class FakeSession:
+    """Records each statement and returns the next canned result."""
+
+    def __init__(self, results):
+        self._results = list(results)
+        self.statements = []
+
+    async def execute(self, statement):
+        self.statements.append(statement)
+        return _Result(self._results.pop(0))
+
+    # -- helpers for assertions --------------------------------------------
+    @property
+    def kinds(self) -> list[str]:
+        """'select' or 'insert', in the order issued."""
+        return [
+            "insert" if s.__class__.__name__.lower().startswith("insert") else "select"
+            for s in self.statements
+        ]
+
+    def sql(self, i: int) -> str:
+        return str(self.statements[i]).lower()
+
+
+def _existing_user(**kw) -> ClientUser:
+    user = ClientUser()
+    user.id = uuid.uuid4()
+    user.client_id = CLIENT_ID
+    user.bsuid = kw.get("bsuid")
+    user.phone_number = kw.get("phone_number")
+    user.display_name = kw.get("display_name")
+    user.is_blocked = False
+    return user
+
+
+async def _resolve(session, **kw):
+    return await _resolve_client_user(
+        session=session,
+        client_id=CLIENT_ID,
+        bsuid=kw.get("bsuid"),
+        phone_number=kw.get("phone_number"),
+        display_name=kw.get("display_name"),
+        now=NOW,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Resolution order
+# ---------------------------------------------------------------------------
+def test_known_bsuid_reuses_row_without_touching_phone():
+    """A customer we already know by BSUID resolves on the first lookup."""
+    known = _existing_user(bsuid=BSUID)
+    session = FakeSession([known])
+
+    got = asyncio.run(_resolve(session, bsuid=BSUID, display_name="Cielo"))
+
+    assert got is known
+    assert session.kinds == ["select"]  # no phone lookup, no insert
+    assert got.display_name == "Cielo"
+    assert got.last_contact_at == NOW
+
+
+def test_privacy_customer_with_no_phone_is_created():
+    """The case that used to be dropped: BSUID only, no phone at all."""
+    created = _existing_user(bsuid=BSUID)
+    session = FakeSession([None, created])
+
+    got = asyncio.run(_resolve(session, bsuid=BSUID, display_name="Cielo"))
+
+    assert got is created
+    # Only one lookup: with no phone there is nothing to fall back to.
+    assert session.kinds == ["select", "insert"]
+
+
+def test_new_bsuid_falls_back_to_phone_for_legacy_customer():
+    """A pre-P14 customer is stored phone-keyed with bsuid NULL — reuse them."""
+    legacy = _existing_user(phone_number=PHONE, display_name="Sebastian")
+    session = FakeSession([None, legacy])
+
+    got = asyncio.run(_resolve(session, bsuid=BSUID, phone_number=PHONE))
+
+    assert got is legacy
+    assert session.kinds == ["select", "select"]  # bsuid, then phone. No insert.
+
+
+def test_phone_fallback_does_not_write_bsuid_back():
+    """The merge is the identity ADR's job. This phase must not do it."""
+    legacy = _existing_user(phone_number=PHONE)
+    session = FakeSession([None, legacy])
+
+    got = asyncio.run(_resolve(session, bsuid=BSUID, phone_number=PHONE))
+
+    assert got.bsuid is None, "fallback must not claim the legacy row for this BSUID"
+    assert got.phone_number == PHONE
+
+
+def test_unknown_bsuid_and_unknown_phone_inserts():
+    created = _existing_user(bsuid=BSUID, phone_number=PHONE)
+    session = FakeSession([None, None, created])
+
+    got = asyncio.run(_resolve(session, bsuid=BSUID, phone_number=PHONE))
+
+    assert got is created
+    assert session.kinds == ["select", "select", "insert"]
+
+
+def test_insert_is_an_upsert_so_a_concurrent_ingest_converges():
+    """The advisory lock is taken later, so this step really can race."""
+    created = _existing_user(bsuid=BSUID)
+    session = FakeSession([None, created])
+
+    asyncio.run(_resolve(session, bsuid=BSUID))
+
+    assert "on conflict" in session.sql(1)
+
+
+def test_no_bsuid_uses_the_original_phone_keyed_upsert():
+    """n8n before Fase 3 sends only a phone. That path must be untouched."""
+    created = _existing_user(phone_number=PHONE)
+    session = FakeSession([created])
+
+    got = asyncio.run(_resolve(session, phone_number=PHONE, display_name="Sebastian"))
+
+    assert got is created
+    assert session.kinds == ["insert"]  # straight to the upsert, no lookups
+    assert "on conflict on constraint uq_client_user_phone" in session.sql(0)
+
+
+# ---------------------------------------------------------------------------
+# Request validation
+# ---------------------------------------------------------------------------
+def test_request_accepts_bsuid_only():
+    req = IngestMessageRequest(chakra_message_id="wamid.x", bsuid=BSUID, content="Hola")
+    assert req.bsuid == BSUID
+    assert req.phone_number is None
+
+
+def test_request_accepts_phone_only_for_the_current_n8n():
+    req = IngestMessageRequest(
+        chakra_message_id="wamid.x", phone_number=PHONE, content="Hola"
+    )
+    assert req.phone_number == PHONE
+    assert req.bsuid is None
+
+
+def test_request_rejects_a_message_with_no_identity_at_all():
+    with pytest.raises(ValidationError, match="at least one"):
+        IngestMessageRequest(chakra_message_id="wamid.x", content="Hola")
+
+
+# ---------------------------------------------------------------------------
+# Masking — must survive a missing phone
+# ---------------------------------------------------------------------------
+def test_mask_phone_tolerates_none():
+    assert _mask_phone(None) == "****"
+
+
+def test_mask_identity_prefers_bsuid_and_never_says_none():
+    assert _mask_identity(BSUID, None).endswith("1667")
+    assert _mask_identity(None, PHONE).endswith("8477")
+    assert _mask_identity(None, None) == "****"
+    assert "None" not in _mask_identity(None, None)


### PR DESCRIPTION
Mensajes de clientes con privacidad de número activada se perdían en silencio. Meta omite `from` y `wa_id` y manda solo el **BSUID** (`CO.1034…`); el sistema no tenía forma de representar a ese cliente. Evidencia: clienta real perdida el 2026-08-04 (ejecución n8n 9459, `Stop` marcado "success" en 15 ms).

Este PR cubre las **Fases 1 y 2** del brief (`docs/briefs/impl-brief-P14-lid-bsuid-final.md`): schema y backend. Las Fases 3 y 4 son n8n vivo y no pasan por acá.

## ⚠️ Orden de puesta en producción — importa

**La migración 012 debe aplicarse ANTES de mergear.**

El modelo ORM ahora declara `bsuid`, así que *toda* consulta de `ClientUser` incluye esa columna. Si el código se despliega sin la columna, no falla solo la ruta nueva: falla **cada ingest**.

La 012 sí es retrocompatible en el otro sentido — se puede aplicar con el código actual desplegado, sin ventana de rotura (verificado: el `ON CONFLICT ON CONSTRAINT uq_client_user_phone` del código vivo sigue funcionando post-migración). Por eso el orden correcto es migración primero, merge después.

## Fase 1 — migración 012

- `client_users.bsuid VARCHAR(140)`, columna propia (no se mete en `phone_number`: son cosas distintas, y es `VARCHAR(20)`)
- Índice único `(client_id, bsuid)`. El BSUID es scoped por WABA (confirmado por Chakra Support): el mismo cliente físico tiene un BSUID distinto por tenant, así que la unicidad es por tenant y **nunca** global
- `phone_number` pasa a NULLABLE

**No dropea `uq_client_user_phone`**, contra lo que pedía el brief: el código vivo lo referencia por nombre en su upsert, así que dropearlo rompería cada ingest hasta desplegar la Fase 2. Y sigue siendo útil — con `phone_number` nullable los NULL no colisionan, así que conserva su invariante entre las filas que sí tienen teléfono.

## Fase 2 — backend

- `models/core.py`: `bsuid`; `phone_number` → `Optional`
- `api/v1/ingest.py`: `bsuid` y `phone_number` opcionales por separado, con validador de "al menos uno". Ambos opcionales a propósito: **esto se despliega antes que la Fase 3**, y el n8n vivo hoy manda solo `phone_number`
- `services/ingest.py`: `_resolve_client_user`, cascada `bsuid` → teléfono → `INSERT ... ON CONFLICT`

El paso por teléfono reusa al cliente pre-P14 para no duplicarlo ni perderle el `profile`, pero **no le graba el `bsuid`**: probar que dos identidades son la misma persona es la fusión, y eso tiene su propio ADR. El insert es un `ON CONFLICT` porque el advisory lock se toma recién en el paso 6, así que ese punto realmente compite.

`_mask_phone` tolera `None` y se agrega `_mask_identity`: con `phone_number` nullable, los dos sitios que lo exponían (audit_log y `user_context`) reventaban con `len(None)`.

## Verificación

**174 tests en verde** (162 previos + 12 nuevos) fijando el orden de resolución y que el fallback no hace write-back.

Los tests con stub compilan el SQL pero no lo ejecutan, así que además se ejercitó contra un Postgres desechable con la 012 aplicada y un cliente pre-P14 sembrado:

| Escenario | Resultado |
|---|---|
| LID puro, sin teléfono (el caso que se perdía) | entra, `phone_number` NULL |
| Mismo BSUID otra vez | reusa la misma fila |
| BSUID nuevo + teléfono pre-P14 | reusa al viejo, sin escribirle el bsuid |
| n8n de hoy (solo teléfono) | misma fila, ruta vieja intacta |

3 filas finales, sin duplicar al cliente existente.

## Lo que este PR NO hace

- No arregla el bug de cara al cliente todavía. El `Set` whitelist `map_webhook_data_arenillo` del workflow `master` sigue destruyendo `from_user_id` antes de que el sub-workflow lo vea — eso es la Fase 3
- No toca el envío (Fase 4, vía `recipient`)
- No hace fusión phone↔BSUID ni maneja `user_id_update` → ADR posterior
- Los tests de integración siguen sin existir (deuda #1): la verificación contra Postgres fue manual y desechable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
